### PR TITLE
feat: Agregar select tipo_inscripcion en asignacion documentos

### DIFF
--- a/src/app/@core/data/models/documento/documento_programa.ts
+++ b/src/app/@core/data/models/documento/documento_programa.ts
@@ -7,4 +7,5 @@ export class DocumentoPrograma {
   PeriodoId: number;
   TipoDocumentoProgramaId: TipoDocumentoPrograma;
   FechaCreacion: Date;
+  TipoInscripcionId: number;
 }

--- a/src/app/pages/admision/asignar_documentos_descuentos/asignar_documentos_descuentos.component.html
+++ b/src/app/pages/admision/asignar_documentos_descuentos/asignar_documentos_descuentos.component.html
@@ -1,4 +1,5 @@
-<nb-card>
+<nb-card  [nbSpinner]="loading || loadingGlobal" nbSpinnerStatus="success" nbSpinnerSize="xxlarge"
+nbSpinnerMessage="{{ 'GLOBAL.cargando' | translate }}">
   <nb-card-body>
     <div class=col-12>
       <fieldset [ngClass]="{'fieldseter':true}" >
@@ -33,7 +34,7 @@
                   <mat-label>{{ 'documento_proyecto.aviso_proyecto' | translate }}:</mat-label>
                   <mat-select [formControl]="Campo1Control"
                               [(ngModel)]="proyectos_selected"
-                              (selectionChange)="savePrograma()">
+                              (selectionChange)="loadTipoInscripcion()">
                               <!-- (selectionChange)="loadCriterios()" -->
                     <mat-option *ngFor="let item of proyectos" [value]="item.Id">{{item.Nombre}}</mat-option>
                   </mat-select>
@@ -42,8 +43,21 @@
                   </mat-error>
                 </mat-form-field>
 
+                <!-- select tipo_inscripcion -->
+                <mat-form-field style="width: 100%;">
+                  <mat-label>{{ 'documento_proyecto.aviso_tipo_inscripcion' | translate }}:</mat-label>
+                  <mat-select [formControl]="Campo2Control"
+                              [(ngModel)]="tipo_inscripcion_selected"
+                              (selectionChange)="savePrograma()">
+                    <mat-option *ngFor="let item of tipos_inscripcion" [value]="item.Id">{{item.Nombre}}</mat-option>
+                  </mat-select>
+                  <mat-error *ngIf="Campo2Control.hasError('required')">
+                    {{ 'documento_proyecto.error_selec_tipo_inscripcion' | translate }}
+                  </mat-error>
+                </mat-form-field>
+
                 <!-- Tag de criterios -->
-                <div class="row" *ngIf="proyectos_selected" style="justify-content: space-around;">
+                <div class="row" *ngIf="tipo_inscripcion_selected" style="justify-content: space-around;">
 
                   <div class="col-sm-6 col-md-4 col-lg-3" align="center" id="info_basica">
 

--- a/src/app/pages/documento_programa/list-documento_programa/list-documento_programa.component.ts
+++ b/src/app/pages/documento_programa/list-documento_programa/list-documento_programa.component.ts
@@ -33,6 +33,7 @@ export class ListDocumentoProgramaComponent implements OnInit {
   source: LocalDataSource = new LocalDataSource();
   estadoObservacion: string = '';
   observacion: string = '';
+  tipoInscripcion: number;
 
   @Input('persona_id')
   set info(info: number) {
@@ -116,7 +117,7 @@ export class ListDocumentoProgramaComponent implements OnInit {
     this.soporteDocumento = [];
     this.percentage = 0;
     this.inscripcionService.get('soporte_documento_programa?query=InscripcionId.Id:' +
-      this.inscripcion + ',DocumentoProgramaId.ProgramaId:' + this.programa).subscribe(
+      this.inscripcion + ',DocumentoProgramaId.ProgramaId:' + this.programa + ',DocumentoProgramaId.TipoInscripcionId:' + this.tipoInscripcion + '&limit=0').subscribe(
         (response: any[]) => {
           console.info(Object.keys(response[0]).length)
           if (Object.keys(response[0]).length > 0) {
@@ -136,7 +137,7 @@ export class ListDocumentoProgramaComponent implements OnInit {
               }
             });
           } else {
-            this.popUpManager.showAlert(this.translate.instant('GLOBAL.info'), this.translate.instant('documento_programa.no_documentos'));
+            this.popUpManager.showInfoToast(this.translate.instant('documento_programa.no_documentos'));
           }
           this.loading = false;
         },
@@ -176,7 +177,10 @@ export class ListDocumentoProgramaComponent implements OnInit {
     this.uid = 0;
     this.soporteDocumento = [];
     this.inscripcion = parseInt(sessionStorage.getItem('IdInscripcion'), 10);
-    this.programa = parseInt(sessionStorage.getItem('ProgramaAcademicoId'), 10)
+    this.programa = parseInt(sessionStorage.getItem('ProgramaAcademicoId'), 10);
+    this.periodo = parseInt(sessionStorage.getItem('IdPeriodo'), 10);
+    this.tipoInscripcion = parseInt(sessionStorage.getItem('IdTipoInscripcion'), 10);
+    
     if (this.inscripcion !== undefined && this.inscripcion !== null && this.inscripcion !== 0 &&
       this.inscripcion.toString() !== '') {
       this.loadData();
@@ -185,9 +189,16 @@ export class ListDocumentoProgramaComponent implements OnInit {
   }
 
   public loadLists() {
-    this.inscripcionService.get('documento_programa?query=Activo:true,ProgramaId:' + this.programa).subscribe(
-      response => {
-        this.tipo_documentos = <any[]>response;
+    this.inscripcionService.get('documento_programa?query=Activo:true,PeriodoId:' + this.periodo + ',ProgramaId:' + this.programa + ',TipoInscripcionId:' + this.tipoInscripcion + '&limit=0').subscribe(
+      (response: Object[]) => {
+        if(response === undefined || response === null){
+          this.popUpManager.showErrorToast(this.translate.instant('ERROR.general'));
+        }
+        else if (response.length == 1 && !response[0].hasOwnProperty('TipoDocumentoProgramaId')){
+        }
+        else{
+          this.tipo_documentos = <any[]>response;
+        }
       },
       error => {
         this.popUpManager.showErrorToast(this.translate.instant('ERROR.general'));

--- a/src/app/pages/documento_proyecto/select-documento-proyecto/select-documento-proyecto.component.html
+++ b/src/app/pages/documento_proyecto/select-documento-proyecto/select-documento-proyecto.component.html
@@ -20,9 +20,11 @@
       <nb-card style="width: 70vw; display: grid;">
         <toaster-container [toasterconfig]="config"></toaster-container>
 
+        <nb-card style="width: 70vw; display: grid;">
+          <nb-card-header style="width: 70vw; display: grid;">
+
         {{ 'documento_proyecto.seleccione_documentos' | translate }}
 
-        <br>
         <mat-form-field style="width: 50%;justify-self: center;">
           <mat-label>{{ 'documento_proyecto.documento_proyecto' | translate }}</mat-label>
 
@@ -35,7 +37,8 @@
           <mat-error *ngIf="Campo2Control.hasError('required')">{{ 'documento_proyecto.erro_selec_documento' | translate }}</mat-error>
         </mat-form-field>
 
-        <br/>
+        </nb-card-header>
+        <nb-card-body style="width: 70vw; display: grid;">
 
         {{ 'documento_proyecto.documentos_seleccionados' | translate }}
 
@@ -47,12 +50,14 @@
             </ng2-smart-table>
           </div>
         </div>
+        </nb-card-body>
 
-        <br/>
+        <nb-card-footer style="width: 70vw; display: grid;">
         <button mat-button  (click)="openListDocumentoComponent()" type="submit"
                 nbButton status="success">{{ 'documento_proyecto.administrar_documento' | translate }}
         </button>
-
+        </nb-card-footer>
+        </nb-card>
       </nb-card>
     </fieldset>
 

--- a/src/app/pages/documento_proyecto/select-documento-proyecto/select-documento-proyecto.component.ts
+++ b/src/app/pages/documento_proyecto/select-documento-proyecto/select-documento-proyecto.component.ts
@@ -134,6 +134,7 @@ export class SelectDocumentoProyectoComponent implements OnInit {
             documentoNuevo.Activo = true;
             documentoNuevo.PeriodoId = parseInt(sessionStorage.getItem('PeriodoId'), 10);
             documentoNuevo.ProgramaId = parseInt(sessionStorage.getItem('ProgramaAcademicoId'), 10);
+            documentoNuevo.TipoInscripcionId = parseInt(sessionStorage.getItem('TipoInscripcionId'), 10);
 
             content = Swal.getHtmlContainer();
             if (content) {
@@ -273,14 +274,21 @@ export class SelectDocumentoProyectoComponent implements OnInit {
   loadDataProyecto() {
     this.loading = true;
     this.documento_proyecto = [];
-    this.inscripcionService.get('documento_programa?query=Activo:true,ProgramaId:' + sessionStorage.getItem('ProgramaAcademicoId')).subscribe(
+    this.inscripcionService.get('documento_programa?query=Activo:true,ProgramaId:' + sessionStorage.getItem('ProgramaAcademicoId') + ',TipoInscripcionId:' + sessionStorage.getItem('TipoInscripcionId') + ',PeriodoId:'+sessionStorage.getItem('PeriodoId') + '&limit=0').subscribe(
       response => {
-        response.forEach(documento => {
-          documento.TipoDocumentoProgramaId.IdDocPrograma = documento.Id;
-          documento.TipoDocumentoProgramaId.FechaPrograma = documento.FechaCreacion;
-          this.documento_proyecto.push(<TipoDocumentoPrograma>documento.TipoDocumentoProgramaId);
-        });
-        this.source.load(this.documento_proyecto);
+        if(response === undefined || response === null){
+          this.popUpManager.showErrorToast(this.translate.instant('ERROR.general'));
+        }
+        else if (response.length == 1 && !response[0].hasOwnProperty('TipoDocumentoProgramaId')){
+        }
+        else{
+          response.forEach(documento => {
+            documento.TipoDocumentoProgramaId.IdDocPrograma = documento.Id;
+            documento.TipoDocumentoProgramaId.FechaPrograma = documento.FechaCreacion;
+            this.documento_proyecto.push(<TipoDocumentoPrograma>documento.TipoDocumentoProgramaId);
+          });
+          this.source.load(this.documento_proyecto);
+        }
         this.loading = false;
       },
       error => {

--- a/src/app/pages/inscripcion/inscripcion_general/inscripcion_general.component.ts
+++ b/src/app/pages/inscripcion/inscripcion_general/inscripcion_general.component.ts
@@ -574,8 +574,9 @@ export class InscripcionGeneralComponent implements OnInit, OnChanges {
     this.loading = true;
     return new Promise((resolve, reject) => {
       this.inscripcionService.get('soporte_documento_programa?query=InscripcionId.Id:' +
-        this.inscripcion.Id + ',DocumentoProgramaId.ProgramaId:' + parseInt(sessionStorage.ProgramaAcademicoId, 10)).subscribe(
+        this.inscripcion.Id + ',DocumentoProgramaId.ProgramaId:' + parseInt(sessionStorage.ProgramaAcademicoId, 10) + ',DocumentoProgramaId.TipoInscripcionId:' + parseInt(sessionStorage.getItem('IdTipoInscripcion'), 10) + '&limit=0').subscribe(
           (res: any[]) => {
+            console.log(res)
             if (res !== null && JSON.stringify(res[0]) !== '{}') {
               this.percentage_docu = 0;
               for (let i = 0; i < res.length; i++) {
@@ -658,7 +659,7 @@ export class InscripcionGeneralComponent implements OnInit, OnChanges {
   }
 
   public loadLists() {
-    this.inscripcionService.get('documento_programa?query=Activo:true,ProgramaId:' + parseInt(sessionStorage.ProgramaAcademicoId, 10)).subscribe(
+    this.inscripcionService.get('documento_programa?query=Activo:true,ProgramaId:' + parseInt(sessionStorage.ProgramaAcademicoId, 10) + ',TipoInscripcionId:' + parseInt(sessionStorage.getItem('IdTipoInscripcion'), 10) + '&limit=0').subscribe(
       response => {
         this.tipo_documentos = <any[]>response;
       },

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -1386,7 +1386,9 @@
       "seleccione_documentos": "Select the documents that you want to assign to the program:",
       "documentos_seleccionados": "Assigned documents:",
       "carga_nuevo_documento": "Assigning new document...",
-      "carga_eliminando_documento": "Removing document from project..."
+      "carga_eliminando_documento": "Removing document from project...",
+      "aviso_tipo_inscripcion": "Select the type of registration for which you want to define the admission documents and discounts",
+      "error_selec_tipo_inscripcion": "Please, select a registration type"
     },
     "descuento_academico": {
       "documento_programa_no_registrado": "Document not registered",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -1415,7 +1415,7 @@
         "aviso_periodo": "Periodo en el cual se define los documentos y descuentos de admisión",
         "aviso_nivel": "Seleccione el nivel al que desea definir los documentos y descuentos de admisión",
         "erro_selec_nivel": "Por favor, seleccione el nivel",
-        "aviso_proyecto": "Seleccione el proyecto curricular que desea definir los documentos y descuentos de admisión",
+        "aviso_proyecto": "Seleccione el proyecto curricular al que desea definir los documentos y descuentos de admisión",
         "erro_selec_proyecto": "Por favor, seleccione al menos un proyecto",
         "erro_selec_documento": "Por favor, seleccione un documento",
         "titulo": "Asignación de documentos y descuentos por proyecto",
@@ -1424,7 +1424,9 @@
         "seleccione_documentos": "Seleccione los documentos que desea asignar al programa:",
         "documentos_seleccionados": "Documentos asignados:",
         "carga_nuevo_documento": "Asignando nuevo documento...",
-        "carga_eliminando_documento": "Eliminando documento del proyecto..."
+        "carga_eliminando_documento": "Eliminando documento del proyecto...",
+        "aviso_tipo_inscripcion": "Seleccione el tipo de inscripción al que desea definir los documentos y descuentos de admisión",
+        "error_selec_tipo_inscripcion": "Por favor, seleccione un tipo de inscripción"
     },
     "descuento_academico": {
         "descuento_academico_no_registrado": "Descuento académico no registrado",


### PR DESCRIPTION
Se agrega select en 'Admisiones/Asignación de documentos y descuentos por proyecto', para discriminar los documentos
requeridos en función también del tipo de inscripción. Se ajustan las peticiones que listan y guardan los documentos
solicitados segun las opciones seleccionadas. Traducción en-es para el select.

Se ajustan las consultas en 'Inscripcion/Preinscripcion' e 'Inscripcion/Transferencia' teniendo en cuenta tipo_inscripción.
Periodo y programa, de tal manera que solamente aparezcan los documentos solicitados en función de lo establecido en Admisiones.
Ajuste de porcentaje completado teniendo en cuenta tipo_inscripcion.