### PR TITLE
fix: Manejo de respuesta a erroes en flujo

### DIFF
--- a/src/app/pages/idiomas/list-idiomas/list-idiomas.component.ts
+++ b/src/app/pages/idiomas/list-idiomas/list-idiomas.component.ts
@@ -132,7 +132,7 @@ export class ListIdiomasComponent implements OnInit {
         this.loading = false;
       },
         (error: HttpErrorResponse) => {
-          this.loading = true;
+          this.loading = false;
           this.popUpManager.showErrorAlert(this.translate.instant('ERROR.' + error.status));
         });
   }

--- a/src/app/pages/propuesta_grado/crud-propuesta_grado/crud-propuesta_grado.component.ts
+++ b/src/app/pages/propuesta_grado/crud-propuesta_grado/crud-propuesta_grado.component.ts
@@ -95,9 +95,14 @@ export class CrudPropuestaGradoComponent implements OnInit {
   }
 
   async cargarValores() {
-    await this.listService.findGrupoInvestigacion();
-    await this.listService.findLineaInvestigacion();
-    await this.listService.findTipoProyecto();
+    try {
+      await this.listService.findGrupoInvestigacion();
+      await this.listService.findLineaInvestigacion();
+      await this.listService.findTipoProyecto();
+    } catch (error) {
+      this.loading = false;
+      this.popUpManager.showErrorToast(this.translate.instant('ERROR.general'));
+    }
   }
 
   construirForm() {
@@ -172,6 +177,8 @@ export class CrudPropuestaGradoComponent implements OnInit {
                   confirmButtonText: this.translate.instant('GLOBAL.aceptar'),
                 });
               })
+        } else {
+          this.loading = false;
         }
       }, (error: HttpErrorResponse) => {
         this.loading = false;


### PR DESCRIPTION
Se ajusta list-idiomas a loading=false cuando error request

En crud-propuesta_grado se añade try catch para manejar error en caso de que alguna funcion con request interna falle, ya que
estas en su controlan el loading. Se tiene en cuenta que una peticion puede retornar json vacío, se detiene el loading en ese caso.