### PR TITLE
feat: for issue #1008, Funcionalidad extension de extension

### DIFF
--- a/src/app/pages/calendario-academico/administracion-calendario/administracion-calendario.component.ts
+++ b/src/app/pages/calendario-academico/administracion-calendario/administracion-calendario.component.ts
@@ -323,6 +323,11 @@ idCalendario: number = 0;
                               });
                               this.processTable.load(this.processes);
                               this.loading = false;
+                            } else {
+                              this.loading = false;
+                            }
+                            if( <boolean>response.Data[0].AplicaExtension ){
+                              this.popUpManager.showAlert(this.translate.instant('calendario.formulario_extension'),this.translate.instant('calendario.calendario_tiene_extension'));
                             }
                           },
                           error => {
@@ -337,7 +342,7 @@ idCalendario: number = 0;
                         this.loading = false;
                         this.popUpManager.showErrorToast(this.translate.instant('ERROR.general'));
                       }
-                    )
+                    );
                   }, error => {
                     console.log("error_calendario_por_dependencia: ", error)
                     this.loading = false;

--- a/src/app/pages/calendario-academico/def-calendario-academico/def-calendario-academico.component.html
+++ b/src/app/pages/calendario-academico/def-calendario-academico/def-calendario-academico.component.html
@@ -1,7 +1,7 @@
+<div [nbSpinner]="loading" nbSpinnerStatus="success" nbSpinnerSize="xxlarge" nbSpinnerMessage="{{ 'GLOBAL.cargando' | translate }}">
 <nb-tabset fullWidth (changeTab)="changeTab($event)">
     <nb-tab tabTitle="{{ 'calendario.definicion' | translate }}" [active]="activetab">
         <div class="dinamic-form">
-            <div [nbSpinner]="loading" nbSpinnerStatus="success" nbSpinnerSize="xxlarge" nbSpinnerMessage="{{ 'GLOBAL.cargando' | translate }}">
                 
                 <form novalidate [formGroup]="calendarForm" #fform="ngForm" (ngSubmit)="createCalendar($event)" class="form-horizontal">
                     <div class="row">
@@ -171,13 +171,26 @@
                         </mat-tab-group>
                     </div>
                 </fieldset>
-            </div>
         </div>
     </nb-tab>
 
     <!-- ///////////// No tocar de aqui para arriba ///////////// -->
 
     <nb-tab tabTitle="{{ 'calendario.formulario_extension' | translate }}" [active]="!activetab">
+        <ng-container *ngIf="showList">
+            <div class="row">
+                <div class="col-12">
+                    <mat-form-field style="width: 100%;" floatLabel="always">
+                        <mat-label> {{ 'calendario.seleccione_version_calendario' | translate }} </mat-label>
+                        <mat-select placeholder="{{ 'calendario.seleccione_version_calendario' | translate }}" [(value)]="selCalendar">
+                            <mat-option *ngFor="let Calendar of ExtensionList" (click)="loadExtension(Calendar.Id)" [value]="Calendar.Id" >
+                                {{ Calendar.Nombre }}
+                            </mat-option>
+                        </mat-select>
+                    </mat-form-field>
+                </div>
+            </div>
+        </ng-container>
         <form novalidate [formGroup]="calendarFormExtend" #fform="ngForm" (ngSubmit)="extendCalendar($event)" class="form-horizontal">
             <div class="row">
                 <div class="col-12">
@@ -279,6 +292,7 @@
             </legend>
 
             <div class="calendar-content" *ngIf="activetabs">
+                <ng-container *ngIf="!Extension && !Ext_Extension">
                 <mat-tab-group>
                     <mat-tab label="{{ 'calendario.procesos' | translate }}">
                         <ng2-smart-table [settings]="processSettings" [source]="processTable" (create)="addProcess($event)" (edit)="editProcess($event)" (delete)="deleteProcess($event)"></ng2-smart-table>
@@ -296,6 +310,28 @@
                         </mat-accordion>
                     </mat-tab>
                 </mat-tab-group>
+                </ng-container>
+
+                <ng-container *ngIf="Extension || Ext_Extension">
+                <mat-tab-group>
+                    <mat-tab label="{{ 'calendario.procesos' | translate }}">
+                        <ng2-smart-table [settings]="processSettings" [source]="processTableExt" (create)="addProcess($event)" (edit)="editProcess($event)" (delete)="deleteProcess($event)"></ng2-smart-table>
+                    </mat-tab>
+                    <mat-tab label="{{ 'calendario.actividades' | translate }}">
+                        <mat-accordion>
+                            <mat-expansion-panel *ngFor="let process of processesExt">
+                                <mat-expansion-panel-header>
+                                    <mat-panel-title>
+                                        {{ process.Nombre }}
+                                    </mat-panel-title>
+                                </mat-expansion-panel-header>
+                                <ng2-smart-table [settings]="activitiesSettings" [source]="process.actividades" (create)="addActivity($event, process)" (custom)="onAction($event, process)" ></ng2-smart-table> <!-- (edit)="editActivity($event, process)" (delete)="deleteActivity($event, process)" -->
+                            </mat-expansion-panel>
+                        </mat-accordion>
+                    </mat-tab>
+                </mat-tab-group>
+                </ng-container>
+
             </div>
         </fieldset>
 
@@ -305,8 +341,12 @@
                 <ng-container *ngIf="!Extension">
                     <button class="float-center" mat-button type="submit" [disabled]="calendarFormExtend.invalid">{{ 'GLOBAL.guardar' | translate }} </button>
                 </ng-container>
+                <ng-container *ngIf="Extension">
+                    <button class="float-center" mat-button type="button" (click)="prepareNewExtension()" > {{ 'calendario.add_extension_extension' | translate }} </button>
+                </ng-container>
             </div>
         </div>
     </form>
     </nb-tab>
 </nb-tabset>
+</div>

--- a/src/app/pages/calendario-academico/proceso-calendario-academico/proceso-calendario-academico.component.ts
+++ b/src/app/pages/calendario-academico/proceso-calendario-academico/proceso-calendario-academico.component.ts
@@ -47,7 +47,8 @@ export class ProcesoCalendarioAcademicoComponent {
       if (ok.value) {
         this.process = this.processForm.value;
         this.process.CalendarioId = {Id: this.data.calendar.calendarioId};
-        this.process.TipoRecurrenciaId = {Id: this.processForm.value.TipoRecurrenciaId}
+        this.process.TipoRecurrenciaId = {Id: this.processForm.value.TipoRecurrenciaId};
+        this.process['Activo'] = true;
         this.dialogRef.close(this.process);
       }
     });

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -1731,7 +1731,15 @@
         "modificacion_fechas_info": "A continuacion usted podrá modificar las fechas de la actividad correspondiente, teniendo en cuenta que el sistema limita su edición al rango de las fechas globales del calendario general.",
         "descripcion": "Descripción",
         "descripcion_proceso": "Descripcion de proceso",
-        "periodicidad_2": "Periodicidad"
+        "periodicidad_2": "Periodicidad",
+
+        "seguro_extension": "Está a punto de crear una extensión de calendario, ¿Desea continuar?",
+        "Extension_calendario_ok": "¡La extensión del calendario se ha realizado correctamente!",
+        "calendario_tiene_extension": "Este calendario cuenta con extensión.",
+        "extension_inactiva": "Esta extensión de calendario está desctivada.",
+        "seleccione_version_calendario": "Seleccione la versión del calendario",
+        "add_extension_extension": "Agregar otra extension",
+        "sin_permiso_edicion": "No tiene permiso para editar esta actividad"
 
     },
     "derechos_pecuniarios": {


### PR DESCRIPTION
A partir del componente de extension de calendario se añade funcionalidad para hacer extensión de la extension.

Cuando hay varias extensiones se carga la última (más actual) y se despliega un select listando todas las extensiones, siendo la primera opción la extensión más actual y la última la más antigua.

Cada vez que se hace un proceso de "extensión de extensión" se desactiva la extensión actual, quedando activa únicamente la nueva; el calendario Original siempre está activo.

Se añaden modales en definicion calendario y Administración calendario indicando si el calendario es de extension.