### PR TITLE
fix: Ajuste relacion nombre - documento en listado de documentos.

### DIFF
--- a/src/app/@core/utils/new_nuxeo.service.ts
+++ b/src/app/@core/utils/new_nuxeo.service.ts
@@ -80,22 +80,21 @@ export class NewNuxeoService {
     get(files) {
         const documentsSubject = new Subject<Documento[]>();
         const documents$ = documentsSubject.asObservable();
-        const documentos = [];
-
-        files.map(async (file, index) => {
+        const documentos = files;
+        let i = 0;
+        files.map((file, index) => {
             this.documentService.get('documento/' + file.Id)
-                .pipe(mergeMap((doc) => {
-                    documentos.push(doc);
-                    return this.anyService.get(environment.NUXEO_SERVICE, '/document/' + doc.Enlace)
-                })
-                )
+            .subscribe((doc) => {
+                this.anyService.get(environment.NUXEO_SERVICE, '/document/' + doc.Enlace)
                 .subscribe(async (f: any) => {
-                    const url = await this.getUrlFile(f.file, f['file:content']['mime-type']);
-                    documentos[index] = { ...documentos[index], ...{ url: url }, ...{ Documento: this.sanitization.bypassSecurityTrustUrl(url) } }
-                    if (documentos.length === files.length) {
+                    const url = await this.getUrlFile(f.file, f['file:content']['mime-type'])
+                    documentos[index] = { ...documentos[index], ...{ url: url }, ...{ Documento: this.sanitization.bypassSecurityTrustUrl(url) } }           
+                    i+=1;
+                    if(i === files.length){
                         documentsSubject.next(documentos);
                     }
                 })
+            })
         });
         return documents$;
     }

--- a/src/app/pages/admision/dialogo-documentos/dialogo-documentos.component.html
+++ b/src/app/pages/admision/dialogo-documentos/dialogo-documentos.component.html
@@ -11,6 +11,14 @@
           </ngx-extended-pdf-viewer>
         </div>
         <div class="col-6 d-flex align-items-start flex-column">
+          <div class="row mb-auto" style="width: 100%;">
+            <div class="col-4">
+              <mat-label>{{ 'GLOBAL.soporte_documento' | translate }}: </mat-label>
+            </div>
+            <div class="col-8">
+              <mat-label> {{ nombreDocumento }} </mat-label>
+            </div>
+          </div>
           <div class="row mb-auto" style="width: 100%;" *ngIf="!observando">
             <div class="col-4">
               <mat-label>{{ 'admision.doc_valido' | translate }}*: </mat-label>
@@ -19,7 +27,7 @@
               <mat-slide-toggle formControlName="aprobado"></mat-slide-toggle>
             </div>
           </div>
-          <div class="row" style="width: 100%;">
+          <div class="row mb-auto" style="width: 100%;">
             <div class="col-3">
               <mat-label>{{ 'GLOBAL.observacion' | translate }}: </mat-label>
             </div>

--- a/src/app/pages/admision/dialogo-documentos/dialogo-documentos.component.ts
+++ b/src/app/pages/admision/dialogo-documentos/dialogo-documentos.component.ts
@@ -13,6 +13,7 @@ export class DialogoDocumentosComponent implements OnInit {
 
   revisionForm: FormGroup;
   documento: any;
+  nombreDocumento: string = "";
   loading: boolean;
   observando: boolean;
 
@@ -29,6 +30,7 @@ export class DialogoDocumentosComponent implements OnInit {
 
   ngOnInit() {
     this.loading = true;
+    this.nombreDocumento = this.data.documento.DocumentoProgramaId.TipoDocumentoProgramaId.Nombre;
     this.documento = this.data.documento.Documento['changingThisBreaksApplicationSecurity'];
     this.observando = this.data.observando;
     this.revisionForm.setValue({

--- a/src/app/pages/admision/evaluacion-documentos-inscritos/evaluacion-documentos-inscritos.component.ts
+++ b/src/app/pages/admision/evaluacion-documentos-inscritos/evaluacion-documentos-inscritos.component.ts
@@ -110,7 +110,7 @@ export class EvaluacionDocumentosInscritosComponent implements OnInit {
   }
 
   loadLevel() {
-    this.projectService.get('nivel_formacion?limit=2').subscribe(
+    this.projectService.get('nivel_formacion?limit=0').subscribe(
       (response: any) => {
         if (response !== null || response !== undefined) {
           this.nivel_load = <any>response;

--- a/src/app/pages/documento_programa/list-documento_programa/list-documento_programa.component.ts
+++ b/src/app/pages/documento_programa/list-documento_programa/list-documento_programa.component.ts
@@ -164,7 +164,7 @@ export class ListDocumentoProgramaComponent implements OnInit {
               const metadatos = JSON.parse(doc.Metadatos);
               if (metadatos.aprobado) {
                 this.estadoObservacion = 'Aprobado';
-                this.observacion = '';
+                this.observacion = metadatos.observacion;
               } else {
                 this.estadoObservacion = 'No aprobado';
                 this.observacion = metadatos.observacion;

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -881,7 +881,10 @@
         "tooltip_crear": "Create academic production",
         "seguro_continuar_registrar": "Are you sure you want to register this new author?",
         "autor_creado": "Author successfully created",
-        "autor_no_creado": "The new author could not be created"
+        "autor_no_creado": "The new author could not be created",
+        "ejecutable_programa": "Application executable file support",
+        "codigo_fuente": "Software source code support",
+        "archivo_video": "Audiovisual production support"
     },
     "archivo_icfes": {
         "archivo_icfes": "Icfes file",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -919,7 +919,10 @@
         "tooltip_crear": "Crear producción académica",
         "seguro_continuar_registrar": "¿Está seguro de registrar al nuevo autor?",
         "autor_creado": "Autor creado exitosamente",
-        "autor_no_creado": "No fue posible crear el nuevo autor"
+        "autor_no_creado": "No fue posible crear el nuevo autor",
+        "ejecutable_programa": "Soporte de archivo ejecutable de aplicación",
+        "codigo_fuente": "Soporte de código fuente del software",
+        "archivo_video": "Soporte de producción audiovisual"
     },
     "archivo_icfes": {
         "archivo_icfes": "Archivo de registros del ICFES",


### PR DESCRIPTION
Se hace ajuste en el servicio new_nuxeo (función get()) para corregir relación entre url y el id del archivo cuando se recorre array de archivos a visualizar.

Se añade en la visualización del documento en admisiones el nombre del archivo para mejor claridad de que archivo se está revisando.

Se añaden los tag de traducción para los formDefinition que hacían falta.