### PR TITLE
fix: Validacion vacio campo NIT

### DIFF
--- a/src/app/pages/experiencia_laboral/crud-experiencia_laboral/crud-experiencia_laboral.component.ts
+++ b/src/app/pages/experiencia_laboral/crud-experiencia_laboral/crud-experiencia_laboral.component.ts
@@ -17,6 +17,7 @@ import { ImplicitAutenticationService } from '../../../@core/utils/implicit_aute
 import { IAppState } from '../../../@core/store/app.state';
 import { Store } from '@ngrx/store';
 import { NewNuxeoService } from '../../../@core/utils/new_nuxeo.service';
+import { PopUpManager } from '../../../managers/popUpManager';
 
 @Component({
   selector: 'ngx-crud-experiencia-laboral',
@@ -89,6 +90,7 @@ export class CrudExperienciaLaboralComponent implements OnInit {
     private listService: ListService,
     private tercerosService: TercerosService,
     private newNuxeoService: NewNuxeoService,
+    private popUpManager: PopUpManager,
     private users: UserService) {
     this.formInfoExperienciaLaboral = FORM_EXPERIENCIA_LABORAL;
     this.construirForm();
@@ -226,21 +228,26 @@ export class CrudExperienciaLaboralComponent implements OnInit {
   }
 
   searchNit(data) {
-    const inombre = this.getIndexForm('NombreEmpresa');
-    const regex = /^[0-9]+(?:-[0-9]+)*$/;
-    data.data.Nit = data.data.Nit.trim();
-    const nit = typeof data === 'string' ? data : data.data.Nit;
+    if(data.data.Nit){
+      const inombre = this.getIndexForm('NombreEmpresa');
+      const regex = /^[0-9]+(?:-[0-9]+)*$/;
+      data.data.Nit = data.data.Nit.trim();
+      const nit = typeof data === 'string' ? data : data.data.Nit;
 
-    if (regex.test(nit) === true) {
-      this.searchOrganizacion(nit);
-      this.indexSelect = null;
-      this.detalleExp = null;
-    } else {
-      this.clean = !this.clean;
-      this.formInfoExperienciaLaboral.campos[inombre].deshabilitar = false;
-      this.loadListEmpresa(nit);
-      this.formInfoExperienciaLaboral.campos[inombre].valor = nit;
+      if (regex.test(nit) === true) {
+        this.searchOrganizacion(nit);
+        this.indexSelect = null;
+        this.detalleExp = null;
+      } else {
+        this.clean = !this.clean;
+        this.formInfoExperienciaLaboral.campos[inombre].deshabilitar = false;
+        this.loadListEmpresa(nit);
+        this.formInfoExperienciaLaboral.campos[inombre].valor = nit;
+      }
+    }  else {
+      this.popUpManager.showAlert(this.translate.instant('inscripcion.experiencia_laboral'), this.translate.instant('GLOBAL.no_vacio'))
     }
+    
   }
 
   getSeleccion(event) {
@@ -259,7 +266,8 @@ export class CrudExperienciaLaboralComponent implements OnInit {
   }
 
   loadListEmpresa(nombre: string): void {
-    let consultaEmpresa: Array<any> = [];
+    if(nombre){
+      let consultaEmpresa: Array<any> = [];
     const empresa: Array<any> = [];
     this.sgaMidService.get('experiencia_laboral/informacion_empresa?nombre=' + nombre)
       .subscribe(res => {
@@ -280,6 +288,9 @@ export class CrudExperienciaLaboralComponent implements OnInit {
             confirmButtonText: this.translate.instant('GLOBAL.aceptar'),
           });
         });
+    } else {
+      this.popUpManager.showAlert(this.translate.instant('inscripcion.experiencia_laboral'), this.translate.instant('GLOBAL.no_vacio'))
+    }
   }
 
   searchOrganizacion(nit: string): void {

--- a/src/app/pages/formacion_academica/crud-formacion_academica/crud-formacion_academica.component.ts
+++ b/src/app/pages/formacion_academica/crud-formacion_academica/crud-formacion_academica.component.ts
@@ -216,84 +216,92 @@ export class CrudFormacionAcademicaComponent implements OnInit {
   }
 
   searchDoc(data) {
-    this.loading = true;
-    const init = this.getIndexForm('Nit');
-    const inombre = this.getIndexForm('NombreUniversidad');
-    const idir = this.getIndexForm('Direccion');
-    const itel = this.getIndexForm('Telefono');
-    const icorreo = this.getIndexForm('Correo');
-    const iPais = this.getIndexForm('Pais');
-    const regex = /^[0-9]+(?:-[0-9]+)*$/;
-    data.data.Nit = data.data.Nit.trim()
-    const nit = typeof data === 'string' ? data : data.data.Nit;
-    let IdUniversidad;
-    if (regex.test(nit) === true) {
-      this.searchNit(nit);
+    if(data.data.Nit){
+      this.loading = true;
+      const init = this.getIndexForm('Nit');
+      const inombre = this.getIndexForm('NombreUniversidad');
+      const idir = this.getIndexForm('Direccion');
+      const itel = this.getIndexForm('Telefono');
+      const icorreo = this.getIndexForm('Correo');
+      const iPais = this.getIndexForm('Pais');
+      const regex = /^[0-9]+(?:-[0-9]+)*$/;
+      data.data.Nit = data.data.Nit.trim()
+      const nit = typeof data === 'string' ? data : data.data.Nit;
+      let IdUniversidad;
+      if (regex.test(nit) === true) {
+        this.searchNit(nit);
 
-      this.info_formacion_academica = undefined;
-      this.info_formacion_academica_id = 0;
-      this.edit_status = false;
-      this.loading = false;
-    } else {
-      if (Object.entries(this.formInfoFormacionAcademica.campos[inombre].valor).length !== 0 &&
-        this.formInfoFormacionAcademica.campos[inombre].valor !== null) {
-        IdUniversidad = this.formInfoFormacionAcademica.campos[this.getIndexForm('NombreUniversidad')].valor.Id;
-        this.tercerosService.get('datos_identificacion?query=TerceroId__Id:' + IdUniversidad).subscribe(
-          (res: any) => {
-            this.searchNit(res[0]['Numero']);
-
-            this.info_formacion_academica = undefined;
-            this.info_formacion_academica_id = 0;
-            this.edit_status = false;
-            this.loading = false;
-          },
-          (error: HttpErrorResponse) => {
-            this.loading = false;
-          },
-        )
-      } else {
+        this.info_formacion_academica = undefined;
+        this.info_formacion_academica_id = 0;
+        this.edit_status = false;
         this.loading = false;
-        [this.formInfoFormacionAcademica.campos[idir],
-        this.formInfoFormacionAcademica.campos[icorreo],
-        this.formInfoFormacionAcademica.campos[iPais],
-        this.formInfoFormacionAcademica.campos[itel]]
-          .forEach(element => {
-            element.deshabilitar = false;
-          });
-        this.loadListUniversidades(nit);
-        this.nit = nit;
-        this.formInfoFormacionAcademica.campos[inombre].valor = nit;
-      }
+      } else {
+        if (Object.entries(this.formInfoFormacionAcademica.campos[inombre].valor).length !== 0 &&
+          this.formInfoFormacionAcademica.campos[inombre].valor !== null) {
+          IdUniversidad = this.formInfoFormacionAcademica.campos[this.getIndexForm('NombreUniversidad')].valor.Id;
+          this.tercerosService.get('datos_identificacion?query=TerceroId__Id:' + IdUniversidad).subscribe(
+            (res: any) => {
+              this.searchNit(res[0]['Numero']);
 
+              this.info_formacion_academica = undefined;
+              this.info_formacion_academica_id = 0;
+              this.edit_status = false;
+              this.loading = false;
+            },
+            (error: HttpErrorResponse) => {
+              this.loading = false;
+            },
+          )
+        } else {
+          this.loading = false;
+          [this.formInfoFormacionAcademica.campos[idir],
+          this.formInfoFormacionAcademica.campos[icorreo],
+          this.formInfoFormacionAcademica.campos[iPais],
+          this.formInfoFormacionAcademica.campos[itel]]
+            .forEach(element => {
+              element.deshabilitar = false;
+            });
+          this.loadListUniversidades(nit);
+          this.nit = nit;
+          this.formInfoFormacionAcademica.campos[inombre].valor = nit;
+        }
+      }
+    } else {
+      this.popUpManager.showAlert(this.translate.instant('inscripcion.formacion_academica'), this.translate.instant('GLOBAL.no_vacio'))
     }
+    
   }
 
   loadListUniversidades(nombre: string): void {
-    this.loading = true;
-    nombre = nombre.trim();
-    let consultaUniversidades: Array<any> = [];
-    const universidad: Array<any> = [];
-    this.sgaMidService.get('formacion_academica/info_universidad_nombre?nombre=' + nombre)
-      .subscribe(res => {
-        if (res !== null) {
-          consultaUniversidades = <Array<InfoPersona>>res;
-          for (let i = 0; i < consultaUniversidades.length; i++) {
-            universidad.push(consultaUniversidades[i]);
+    if (nombre) {
+      this.loading = true;
+      nombre = nombre.trim();
+      let consultaUniversidades: Array<any> = [];
+      const universidad: Array<any> = [];
+      this.sgaMidService.get('formacion_academica/info_universidad_nombre?nombre=' + nombre)
+        .subscribe(res => {
+          if (res !== null) {
+            consultaUniversidades = <Array<InfoPersona>>res;
+            for (let i = 0; i < consultaUniversidades.length; i++) {
+              universidad.push(consultaUniversidades[i]);
+            }
           }
-        }
-        this.loading = false;
-        this.formInfoFormacionAcademica.campos[this.getIndexForm('NombreUniversidad')].opciones = universidad;
-      },
-        (error: HttpErrorResponse) => {
           this.loading = false;
-          Swal.fire({
-            icon: 'error',
-            title: error.status + '',
-            text: this.translate.instant('ERROR.' + error.status),
-            footer: this.translate.instant('informacion_academica.error_cargar_universidad'),
-            confirmButtonText: this.translate.instant('GLOBAL.aceptar'),
+          this.formInfoFormacionAcademica.campos[this.getIndexForm('NombreUniversidad')].opciones = universidad;
+        },
+          (error: HttpErrorResponse) => {
+            this.loading = false;
+            Swal.fire({
+              icon: 'error',
+              title: error.status + '',
+              text: this.translate.instant('ERROR.' + error.status),
+              footer: this.translate.instant('informacion_academica.error_cargar_universidad'),
+              confirmButtonText: this.translate.instant('GLOBAL.aceptar'),
+            });
           });
-        });
+      } else {
+        this.popUpManager.showAlert(this.translate.instant('inscripcion.formacion_academica'), this.translate.instant('GLOBAL.no_vacio'))
+      }
   }
 
   public loadInfoFormacionAcademica(): void {

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -613,7 +613,8 @@
         "placeholder_vacio": " ",
         "info_practicas_academicas": "Academic Practice Request",
         "error_practicas_academicas": "It was not possible to record the academic practice",
-        "practicas_academicas": "Academic Practice"
+        "practicas_academicas": "Academic Practice",
+        "no_vacio": "The field cannot be empty"
     },
     "ERROR": {
         "general": "The request could not be satisfied",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -652,7 +652,8 @@
         "info_practicas_academicas": "Solicitud de prácticas académicas",
         "error_practicas_academicas": "No fue posible registrar la práctica académica",
         "practicas_academicas": "Prácticas académicas",
-        "enviar": "Enviar"
+        "enviar": "Enviar",
+        "no_vacio": "El campo no puede estar vacío"
     },
     "ERROR": {
         "general": "La solicitud no pudo ser cumplida",


### PR DESCRIPTION
Se valida campo NIT en Componentes [crud_formacion_academica] y [crud_experiencia_laboral] para evitar consultas cuando el campo es vacío.