### PR TITLE
hotfix: habilita selects periodo

### DIFF
--- a/src/app/pages/admision/evaluacion-aspirantes/evaluacion-aspirantes.component.html
+++ b/src/app/pages/admision/evaluacion-aspirantes/evaluacion-aspirantes.component.html
@@ -12,7 +12,7 @@
                 <!-- select periodo -->
                 <mat-form-field style="width: 35%;">
                   <mat-label>{{ 'admision.aviso_periodo' | translate }}:</mat-label>
-                  <mat-select [(ngModel)]="periodo" [disabled]='true'>
+                  <mat-select [(ngModel)]="periodo" [disabled]='false' (selectionChange)="changePeriodo()">
                     <mat-option *ngFor="let item of periodos" [value]="item"> {{item.Nombre}} </mat-option>
                   </mat-select>
                 </mat-form-field>

--- a/src/app/pages/admision/evaluacion-aspirantes/evaluacion-aspirantes.component.ts
+++ b/src/app/pages/admision/evaluacion-aspirantes/evaluacion-aspirantes.component.ts
@@ -158,7 +158,7 @@ export class EvaluacionAspirantesComponent implements OnInit {
 
   cargarPeriodo() {
     return new Promise((resolve, reject) => {
-      this.parametrosService.get('periodo/?query=Activo:true,CodigoAbreviacion:PA&sortby=Id&order=desc&limit=1')
+      this.parametrosService.get('periodo/?query=CodigoAbreviacion:PA&sortby=Id&order=desc&limit=0')
         .subscribe(res => {
           const r = <any>res;
           if (res !== null && r.Status === '200') {
@@ -175,6 +175,11 @@ export class EvaluacionAspirantesComponent implements OnInit {
             reject(error);
           });
     });
+  }
+
+  changePeriodo() {
+    this.CampoControl.setValue('');
+    this.Campo1Control.setValue('');
   }
 
   loadLevel() {

--- a/src/app/pages/admision/evaluacion-documentos-inscritos/evaluacion-documentos-inscritos.component.html
+++ b/src/app/pages/admision/evaluacion-documentos-inscritos/evaluacion-documentos-inscritos.component.html
@@ -10,7 +10,7 @@
           <!--Periodo académico-->
           <mat-form-field style="width: 35%;">
             <mat-label>{{ 'admision.periodo_' | translate }}:</mat-label>
-            <mat-select [(ngModel)]="periodo" [disabled]='true'>
+            <mat-select [(ngModel)]="periodo" [disabled]='false' (selectionChange)="changePeriodo()">
               <mat-option *ngFor="let item of periodos" [value]="item"> {{item.Nombre}} </mat-option>
             </mat-select>
           </mat-form-field>

--- a/src/app/pages/admision/evaluacion-documentos-inscritos/evaluacion-documentos-inscritos.component.ts
+++ b/src/app/pages/admision/evaluacion-documentos-inscritos/evaluacion-documentos-inscritos.component.ts
@@ -90,7 +90,7 @@ export class EvaluacionDocumentosInscritosComponent implements OnInit {
 
   cargarPeriodo() {
     return new Promise((resolve, reject) => {
-      this.parametrosService.get('periodo/?query=Activo:true,CodigoAbreviacion:PA&sortby=Id&order=desc&limit=1')
+      this.parametrosService.get('periodo/?query=CodigoAbreviacion:PA&sortby=Id&order=desc&limit=0')
         .subscribe(res => {
           const r = <any>res;
           if (res !== null && r.Status === '200') {
@@ -107,6 +107,11 @@ export class EvaluacionDocumentosInscritosComponent implements OnInit {
             reject(error);
           });
     });
+  }
+
+  changePeriodo() {
+    this.CampoControl.setValue('');
+    this.Campo1Control.setValue('');
   }
 
   loadLevel() {

--- a/src/app/pages/admision/listado_aspirantes/listado_aspirante.component.html
+++ b/src/app/pages/admision/listado_aspirantes/listado_aspirante.component.html
@@ -45,8 +45,7 @@
             <!-- select periodo -->
             <mat-form-field style="width: 40%;">
               <mat-label>{{ 'calendario.periodo' | translate }}:</mat-label>
-              <mat-select [(ngModel)]="periodo" [disabled]='true'>
-                <mat-option>--Seleccionar--</mat-option>
+              <mat-select [(ngModel)]="periodo" [disabled]='false' (selectionChange)="changePeriodo()">
                 <mat-option *ngFor="let item of periodos" [value]="item">
                   {{item.Nombre}}
                 </mat-option>

--- a/src/app/pages/admision/listado_aspirantes/listado_aspirante.component.ts
+++ b/src/app/pages/admision/listado_aspirantes/listado_aspirante.component.ts
@@ -209,7 +209,7 @@ export class ListadoAspiranteComponent implements OnInit, OnChanges {
 
   cargarPeriodo() {
     return new Promise((resolve, reject) => {
-      this.parametrosService.get('periodo/?query=Activo:true,CodigoAbreviacion:PA&sortby=Id&order=desc&limit=1')
+      this.parametrosService.get('periodo/?query=CodigoAbreviacion:PA&sortby=Id&order=desc&limit=0')
         .subscribe(res => {
           const r = <any>res;
           if (res !== null && r.Status === '200') {
@@ -226,6 +226,11 @@ export class ListadoAspiranteComponent implements OnInit, OnChanges {
             reject(error);
           });
     });
+  }
+
+  changePeriodo() {
+    this.CampoControl.setValue('');
+    this.Campo1Control.setValue('');
   }
 
   nivel_load() {


### PR DESCRIPTION
- Se habilita y cargan todos los periodos para:
  - Evaluacion documentos inscritos
  - Evaluacion aspirantes
  - Listar aspirantes

- Se añade funcion simple para de-seleccionar las otras opciones (nivel, programa) cuando el periodo cambia, ya que por defecto la consulta no se vuelve a ejectuar sino hasta que se cambie la ultima opcion (programa)