### PR TITLE
feat: #1085 Ajuste flujo login, consulta existencia tercero

### DIFF
--- a/src/app/@core/data/users.service.ts
+++ b/src/app/@core/data/users.service.ts
@@ -19,43 +19,127 @@ export class UserService {
 
   constructor(private anyService: AnyService, private autenticationService: ImplicitAutenticationService) {
     if (window.localStorage.getItem('id_token') !== null && window.localStorage.getItem('id_token') !== undefined) {
-      const id_token = window.localStorage.getItem('id_token').split('.');
-      const payload = JSON.parse(atob(id_token[1]));
-      this.autenticationService.getDocument().then((document: string) => {
+      /* const id_token = window.localStorage.getItem('id_token').split('.');
+      const payload = JSON.parse(atob(id_token[1])); */
+      let DocIdentificacion = null;
+      let CorreoUsuario = null;
+      let UsuarioWSO2 = null;
+
+      this.autenticationService.getDocument().then(async (document: string) => {
         if (document) {
-          console.log("getUser", document);
-          this.anyService.get(path, 'datos_identificacion?query=Activo:true,Numero:' + document)
-            .subscribe(res => {
-              if (res !== null) {
-                this.user = res[0].TerceroId;
-                this.user['Documento'] = document;
-                if (Object.keys(this.user).length !== 0) {
-                  this.user$.next(this.user);
-                  this.userSubject.next(this.user);              // window.localStorage.setItem('ente', res[0].Ente);
-                  window.localStorage.setItem('persona_id', this.user.Id);
-                } else {
-                  //this.user$.next(this.user);
-                  window.localStorage.setItem('persona_id', '0');
-                }
-              }
-            });
-        } else if (payload.sub) {
-          this.anyService.get(path, 'tercero?query=UsuarioWSO2:' + payload.sub)
-            .subscribe(res => {
-              if (res !== null) {
-                this.user = res[0];
-                this.user$.next(this.user);
-                this.userSubject.next(this.user);
-                window.localStorage.setItem('persona_id', this.user.Id);
-              }
-              else {
-                //this.user$.next(this.user);
-                window.localStorage.setItem('persona_id', '0');
-              }
-            })
+          DocIdentificacion = document;
         }
-      })
+        let payload = this.autenticationService.getPayload();
+        UsuarioWSO2 = payload.sub? payload.sub : null;
+        CorreoUsuario = payload.email ? payload.email : null;
+
+        console.log([DocIdentificacion, UsuarioWSO2, CorreoUsuario]);
+
+        let foundId: boolean = false;
+
+        if (DocIdentificacion) {
+          console.log("por doc...")
+          await this.findByDocument(DocIdentificacion, UsuarioWSO2, CorreoUsuario).then(found => foundId = true).catch(e => foundId = false);
+        }
+
+        if (UsuarioWSO2 && !foundId) {
+          console.log("por user...")
+          await this.findByUserEmail(UsuarioWSO2).then(found => foundId = true).catch(e => foundId = false);
+        }
+
+        if (CorreoUsuario && !foundId) {
+          console.log("por mail...")
+          await this.findByUserEmail(CorreoUsuario).then(found => foundId = true).catch(e => foundId = false);
+        }
+
+        if (!foundId) {
+          console.log("pailas... o Nuevo registro?")
+          window.localStorage.setItem('persona_id', '0');
+        }
+
+      });
     }
+  }
+
+  private findByDocument(DocIdentificacion, Usuario, Correo){
+    return new Promise<boolean>((resolve, reject) => {
+     this.anyService.get(path, 'datos_identificacion?query=Activo:true,Numero:' + DocIdentificacion + '&sortby=FechaCreacion&order=desc')
+      .subscribe((res: any[]) => {
+        if (res !== null) {
+          if (res.length > 1) {
+            console.log("Hay varios documentos");
+            let tercero = null;
+            console.log("Check por User...");
+            for (let i = 0; i < res.length; i++) {
+              if (res[i].TerceroId.UsuarioWSO2 == Usuario){
+                tercero = res[i].TerceroId;
+                break;
+              }
+            }
+            if(tercero == null){
+              console.log("Check por Correo...");
+              for (let i = 0; i < res.length; i++) {
+                if (res[i].TerceroId.UsuarioWSO2 == Correo){
+                  tercero = res[i].TerceroId;
+                  break;
+                }
+              } 
+            }
+            if(tercero != null) {
+              this.user = tercero;
+            } else {
+              console.log("No coinciden, se toma el más reciente");
+              this.user = res[0].TerceroId;
+            }
+          } else {
+            console.log("Solo hay uno")
+            this.user = res[0].TerceroId;
+          }
+          
+          this.user['Documento'] = DocIdentificacion;
+          if (Object.keys(this.user).length !== 0) {
+            this.user$.next(this.user);
+            this.userSubject.next(this.user);              // window.localStorage.setItem('ente', res[0].Ente);
+            console.log(this.user.Id);
+            window.localStorage.setItem('persona_id', this.user.Id);
+            resolve(true);
+          } else {
+            //this.user$.next(this.user);
+            window.localStorage.setItem('persona_id', '0');
+            reject(false);
+          }
+        } else {
+          reject(false);
+        }
+      });
+    });
+  }
+
+  private findByUserEmail(UserEmail){
+    return new Promise<boolean>((resolve, reject) => {
+    this.anyService.get(path, 'tercero?query=UsuarioWSO2:' + UserEmail)
+      .subscribe(res => {
+        if (res !== null) {
+          this.user = res[0];
+          if (Object.keys(this.user).length !== 0) {
+            this.user$.next(this.user);
+            this.userSubject.next(this.user);
+            console.log(this.user.Id);
+            window.localStorage.setItem('persona_id', this.user.Id);
+            resolve(true);
+          } else {
+            //this.user$.next(this.user);
+            window.localStorage.setItem('persona_id', '0');
+            reject(false);
+          }
+        }
+        else {
+          //this.user$.next(this.user);
+          window.localStorage.setItem('persona_id', '0');
+          reject(false);
+        }
+      });
+    });
   }
 
   // public getEnte(): number {

--- a/src/app/managers/popUpManager.ts
+++ b/src/app/managers/popUpManager.ts
@@ -72,4 +72,16 @@ export class PopUpManager {
         };
         return Swal.fire(options);
     }
+
+    public showPopUpGeneric(title, text, type, cancelar): Promise<any> {
+        const opt: any = {
+            title: title,
+            text: text,
+            icon: type,
+            showCancelButton: cancelar,
+            confirmButtonText: this.translate.instant('GLOBAL.aceptar'),
+            cancelButtonText: this.translate.instant('GLOBAL.cancelar'),
+        };
+        return Swal.fire(opt);
+    }
 }

--- a/src/app/pages/idiomas/list-idiomas/list-idiomas.component.ts
+++ b/src/app/pages/idiomas/list-idiomas/list-idiomas.component.ts
@@ -118,7 +118,7 @@ export class ListIdiomasComponent implements OnInit {
   loadData(): void {
     this.loading = true;
     this.persona_id = this.userService.getPersonaId() || 1;
-    this.idiomaService.get('conocimiento_idioma?query=TercerosId:' + this.persona_id +
+    this.idiomaService.get('conocimiento_idioma?query=Activo:true,TercerosId:' + this.persona_id +
       '&limit=0')
       .subscribe(res => {
         if (res !== null && JSON.stringify(res[0]) !== '{}') {
@@ -154,7 +154,9 @@ export class ListIdiomasComponent implements OnInit {
       .then((willDelete) => {
         this.loading = true;
         if (willDelete.value) {
-          this.idiomaService.delete('conocimiento_idioma', event.data).subscribe(res => {
+          event.data.Activo = false;
+          this.idiomaService.put('conocimiento_idioma', event.data).subscribe(res => {
+          //this.idiomaService.delete('conocimiento_idioma', event.data).subscribe(res => {
             if (res !== null) {
               this.loadData();
               this.popUpManager.showInfoToast(

--- a/src/app/pages/info_persona/crud-info_persona/crud-info_persona.component.html
+++ b/src/app/pages/info_persona/crud-info_persona/crud-info_persona.component.html
@@ -6,7 +6,8 @@
                      [modeloData]="info_info_persona"
                      (result)="validarForm($event)"
                      [clean]="clean"
-                     (percentage)="setPercentage($event)">
+                     (percentage)="setPercentage($event)"
+                     (interlaced)="checkExistePersona($event)">
     </ngx-dinamicform>
 </nb-card>
 <!--ngx-loading [hidden]="!loading"></ngx-loading-->

--- a/src/app/pages/info_persona/crud-info_persona/crud-info_persona.component.ts
+++ b/src/app/pages/info_persona/crud-info_persona/crud-info_persona.component.ts
@@ -22,6 +22,9 @@ export class CrudInfoPersonaComponent implements OnInit {
   info_persona_id: number;
   inscripcion_id: number;
   loading: boolean = false;
+  faltandatos: boolean = false;
+  existePersona: boolean = false;
+  datosEncontrados: any;
 
   @Input('info_persona_id')
   set persona(info_persona_id: number) {
@@ -65,7 +68,7 @@ export class CrudInfoPersonaComponent implements OnInit {
     private store: Store<IAppState>,
     private listService: ListService,
   ) {
-      this.formInfoPersona = FORM_INFO_PERSONA;
+      this.formInfoPersona = {...FORM_INFO_PERSONA};
       this.construirForm();
       this.translate.onLangChange.subscribe((event: LangChangeEvent) => {
         this.construirForm();
@@ -110,6 +113,7 @@ export class CrudInfoPersonaComponent implements OnInit {
           if (res !== null && res.Id !== undefined) {
             const temp = <InfoPersona>res;
             this.info_info_persona = temp;
+            this.datosEncontrados = {...res}
             const files = []
             this.formInfoPersona.btn = '';
             this.formInfoPersona.campos[this.getIndexForm('Genero')].valor = temp.Genero;
@@ -139,7 +143,113 @@ export class CrudInfoPersonaComponent implements OnInit {
       this.loading = false;
       this.popUpManager.showAlert(this.translate.instant('GLOBAL.info'), this.translate.instant('GLOBAL.no_info_persona'));
     }
-    this.formInfoPersona.campos[this.getIndexForm('CorreoElectronico')].valor = this.autenticationService.getPayload().sub;
+    this.formInfoPersona.campos[this.getIndexForm('CorreoElectronico')].valor = this.autenticationService.getPayload().email;
+  }
+
+  checkExistePersona(e) {
+    let doc = this.formInfoPersona.campos[this.getIndexForm('NumeroIdentificacion')].valor;
+    let verif = this.formInfoPersona.campos[this.getIndexForm('VerificarNumeroIdentificacion')].valor
+    if((doc && verif) && (doc == verif)) {
+      this.loading = true;
+      this.sgamidService.get('persona/existe_persona/'+doc).subscribe(
+        (res) => {
+          console.log(res);
+          this.loading = false;
+          this.info_info_persona = res[0];
+          this.datosEncontrados = {...res[0]};
+          this.formInfoPersona.campos.splice(this.getIndexForm('VerificarNumeroIdentificacion'),1);
+
+          this.popUpManager.showPopUpGeneric(this.translate.instant('inscripcion.persona_ya_existe'), this.translate.instant('inscripcion.info_persona_ya_existe'),'info',false).then(()=>{
+            this.formInfoPersona.campos.forEach(campo => {
+              if(campo.valor){
+                campo.deshabilitar = true;
+                if(campo.nombre == "EstadoCivil" || campo.nombre == "OrientacionSexual" || campo.nombre == "IdentidadGenero"){
+                  campo.deshabilitar = false;
+                }
+              }
+            });
+          });
+          this.existePersona = true;
+        },
+        error => {
+          console.log(error);
+          this.loading = false;
+        }
+      );
+    }
+  }
+
+  updateInfoPersona(infoPersona: any) {
+    let prepareUpdate: any = {
+      Tercero: { hasId: null, data: {} },
+      Identificacion: { hasId: null, data: {} },
+      Complementarios: {
+        Genero: { hasId: null, data: {} },
+        EstadoCivil: { hasId: null, data: {} },
+        OrientacionSexual: { hasId: null, data: {} },
+        IdentidadGenero: { hasId: null, data: {} },
+      } 
+    }
+    console.log(infoPersona)
+
+    prepareUpdate.Tercero.hasId = infoPersona.Id;
+
+    if(!this.datosEncontrados.PrimerNombre) {
+      prepareUpdate.Tercero.data["PrimerNombre"] = infoPersona.PrimerNombre;
+    }
+    if(!this.datosEncontrados.SegundoNombre) {
+      prepareUpdate.Tercero.data["SegundoNombre"] = infoPersona.SegundoNombre;
+    }
+    if(!this.datosEncontrados.PrimerApellido) {
+      prepareUpdate.Tercero.data["PrimerApellido"] = infoPersona.PrimerApellido;
+    }
+    if(!this.datosEncontrados.SegundoApellido) {
+      prepareUpdate.Tercero.data["SegundoApellido"] = infoPersona.SegundoApellido;
+    }
+    if(!this.datosEncontrados.FechaNacimiento) {
+      prepareUpdate.Tercero.data["FechaNacimiento"] = momentTimezone.tz(infoPersona.FechaNacimiento, 'America/Bogota').format('YYYY-MM-DD HH:mm:ss') + ' +0000 +0000';
+    }
+    if(!this.datosEncontrados.UsuarioWSO2) {
+      prepareUpdate.Tercero.hasId = infoPersona.Id;
+      prepareUpdate.Tercero.data["UsuarioWSO2"] = this.autenticationService.getPayload().email;
+    }
+
+    if(!this.datosEncontrados.FechaExpedicion) {
+      prepareUpdate.Identificacion.hasId = this.datosEncontrados.IdentificacionId;
+      prepareUpdate.Identificacion.data = {
+        FechaExpedicion: momentTimezone.tz(infoPersona.FechaExpedicion, 'America/Bogota').format('YYYY-MM-DD HH:mm:ss') + ' +0000 +0000',
+      }
+    }
+
+    if(this.datosEncontrados.hasOwnProperty('Genero')){
+      prepareUpdate.Complementarios.EstadoCivil.hasId = this.datosEncontrados.GeneroId;
+    }
+    prepareUpdate.Complementarios.Genero.data = infoPersona.Genero;
+
+    if(this.datosEncontrados.hasOwnProperty('EstadoCivil')){
+      prepareUpdate.Complementarios.EstadoCivil.hasId = this.datosEncontrados.EstadoCivilId;
+    }
+    prepareUpdate.Complementarios.EstadoCivil.data = infoPersona.EstadoCivil;
+
+    if(this.datosEncontrados.hasOwnProperty('OrientacionSexual')){
+      prepareUpdate.Complementarios.OrientacionSexual.hasId = this.datosEncontrados.OrientacionSexualId;
+    }
+    prepareUpdate.Complementarios.OrientacionSexual.data = infoPersona.OrientacionSexual;
+
+    if(this.datosEncontrados.hasOwnProperty('IdentidadGenero')){
+      prepareUpdate.Complementarios.IdentidadGenero.hasId = this.datosEncontrados.IdentidadGeneroId;
+    }
+    prepareUpdate.Complementarios.IdentidadGenero.data = infoPersona.IdentidadGenero;
+    
+    this.sgamidService.put('persona/actualizar_persona',prepareUpdate).subscribe((response) => {
+      this.faltandatos = false;
+      this.existePersona = false;
+      this.formInfoPersona.btn = '';
+      this.popUpManager.showSuccessAlert(this.translate.instant('GLOBAL.persona_actualizado'));
+    },
+    (error: HttpErrorResponse) => {
+      this.popUpManager.showErrorAlert(this.translate.instant('GLOBAL.error_actualizar_persona'));
+    });
   }
 
   createInfoPersona(infoPersona: any): void {
@@ -164,7 +274,7 @@ export class CrudInfoPersonaComponent implements OnInit {
           this.info_info_persona.FechaExpedicion = momentTimezone.tz(this.info_info_persona.FechaExpedicion, 'America/Bogota').format('YYYY-MM-DD HH:mm:ss');
           this.info_info_persona.FechaExpedicion = this.info_info_persona.FechaExpedicion + ' +0000 +0000';
           this.info_info_persona.NumeroIdentificacion = (this.info_info_persona.NumeroIdentificacion).toString();
-          this.info_info_persona.Usuario = this.autenticationService.getPayload().sub;
+          this.info_info_persona.Usuario = this.autenticationService.getPayload().email;
           console.log(this.info_info_persona);
           this.sgamidService.post('persona/guardar_persona', this.info_info_persona).subscribe(res => {
             const r = <any>res
@@ -225,11 +335,15 @@ export class CrudInfoPersonaComponent implements OnInit {
     })
       .then((result) => {
         if (result.value) {
-          if (this.info_info_persona === undefined) {
-            this.createInfoPersona(event.data.InfoPersona);
-          } else {
-            this.formInfoPersona.btn = '';
-          }
+          //if (this.info_info_persona === undefined) {
+            if(this.existePersona || this.faltandatos){
+              this.updateInfoPersona(event.data.InfoPersona);
+            } else {
+              this.createInfoPersona(event.data.InfoPersona);
+            }
+          //} else {
+          //  this.formInfoPersona.btn = '';
+          //}
         } else if (result.value === 0) {
           Swal.fire({
             icon: 'error',
@@ -244,6 +358,16 @@ export class CrudInfoPersonaComponent implements OnInit {
   setPercentage(event) {
     this.percentage = event;
     this.result.emit(this.percentage);
+    console.log(this.percentage);
+    if(this.percentage < 1.0) {
+      this.formInfoPersona.campos.forEach(campo => {
+        if(!campo.valor) {
+          campo.deshabilitar = false;
+        }
+      });
+      this.formInfoPersona.btn = this.translate.instant('GLOBAL.guardar');
+      this.faltandatos = true;
+    }
   }
 
   public loadLists() {

--- a/src/app/pages/info_persona/crud-info_persona/form-info_persona.ts
+++ b/src/app/pages/info_persona/crud-info_persona/form-info_persona.ts
@@ -62,6 +62,7 @@ export let FORM_INFO_PERSONA = {
             mensajeIguales: 'Los datos no coinciden',
             tipo: 'number',
             minimo: 0,
+            entrelazado: true,
         },
         {
             etiqueta: 'inputConfirmacion',
@@ -73,6 +74,7 @@ export let FORM_INFO_PERSONA = {
             tipo: 'number',
             minimo: 0,
             mensajeIguales: 'Los datos no coinciden',
+            entrelazado: true,
         },
         {
             etiqueta: 'mat-date',
@@ -145,15 +147,6 @@ export let FORM_INFO_PERSONA = {
             requerido: true,
             tipo: 'text',
             deshabilitar: true,
-        },
-        {
-            etiqueta: 'input',
-            claseGrid: 'col-lg-3 col-md-6 col-sm-12 col-xs-12',
-            nombre: 'CorreoElectronicoAlterno',
-            label_i18n: 'correo_alterno',
-            placeholder_i18n: 'correo__alterno',
-            requerido: true,
-            tipo: 'text',
-        },
+        }
     ],
 }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -621,7 +621,9 @@
         "placeholder_identidad_genero": "E.g: Cisgender",
         "verificar_numero_documento": "Check document number",
         "placeholder_verificar_numero_documento": "E.g: 55555555",
-        "no_coinciden": "The data does not match"
+        "no_coinciden": "The data does not match",
+        "persona_actualizado": "Your personal information has been successfully updated!",
+        "error_actualizar_persona": "Unable to update your personal information"
     },
     "ERROR": {
         "general": "The request could not be satisfied",
@@ -1306,7 +1308,9 @@
         "solicitud_generada": "The request was successfully generated",
         "placeholder_comentarios": "Comment regarding the request",
         "inscripcion_general": "General information",
-        "generar_matricula": "Generate registration receipt"
+        "generar_matricula": "Generate registration receipt",
+        "persona_ya_existe": "The SGA system has found personal information related to the document number filled out!",
+        "info_persona_ya_existe": "In order to avoid duplication of information, the data found will be used to continue the registration process.\nIf you consider that the data presented does not coincide, you must make a formal request to the Systems Advisory Office, which will review the veracity of the data."
     },
     "reingreso": {
         "reingreso_no_registrado": "Re-entry request not created",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -660,7 +660,9 @@
         "placeholder_identidad_genero": "Ej: Cisgénero",
         "verificar_numero_documento": "Verificar numero de documento",
         "placeholder_verificar_numero_documento": "Ej: 55555555",
-        "no_coinciden": "Los datos no coinciden"
+        "no_coinciden": "Los datos no coinciden",
+        "persona_actualizado": "¡Su información personal ha sido actualizada correctamente!",
+        "error_actualizar_persona": "No se ha podido actualizar su información personal"
     },
     "ERROR": {
         "general": "La solicitud no pudo ser cumplida",
@@ -1346,7 +1348,9 @@
         "placeholder_comentarios": "Comentario respecto a la solicitud",
         "inscripcion_general": "Información general",
         "generar_matricula": "Generar recibo de matrícula",
-        "no_fechas_inscripcion": "El proyecto curricular seleccionado no presenta fechas de inscripcion"
+        "no_fechas_inscripcion": "El proyecto curricular seleccionado no presenta fechas de inscripcion",
+        "persona_ya_existe": "¡El sistema SGA ha encontrado información personal relacionada con el numero de documento diligenciado!",
+        "info_persona_ya_existe": "Con el fin de evitar duplicado de información se utilizarán los datos encontrados para continuar el proceso de inscripción.\nSi considera que los datos presentados no coinciden debe realizar una solicitud formal a la Oficina Asesora de Sistemas quien revisará la veracidad de los datos."
     },
     "reingreso": {
         "reingreso_no_registrado": "Solicitud de reingreso no registrada",


### PR DESCRIPTION
- Se hace ajuste del flujo de sesión para consultar Id de tercero por distintos métodos: documento, usuario y correo
- Durante diligencia de formulación Información Personal en módulo de Inscripción se consulta mediante número de documento si ya existe el tercero, de ser así trae la información existente y se autocompleta el formulario según los campos que tengan valor, los que no serán diligenciados por el usuario. Al guardar en dada situación ya no creará tercero sino que relacionará la información con el Id de tercero existente.
- _Ajuste metodo delete a put en list-idiomas, para issue #1086_