### PR TITLE
hotfix: cambio flujo consulta aspirantes de cliente a mid

### DIFF
--- a/src/app/pages/admision/evaluacion-aspirantes/evaluacion-aspirantes.component.html
+++ b/src/app/pages/admision/evaluacion-aspirantes/evaluacion-aspirantes.component.html
@@ -106,6 +106,9 @@
               </label>
             </div>
             <br/>
+            <div class="d-flex justify-content-around align-items-center">
+                <p>{{ 'admision.total_aspirantes' | translate }}: <b>{{cantidad_aspirantes}}</b></p>
+            </div>
             <ng2-smart-table [settings]="settings"
                              [source]="dataSource"
                              (editConfirm)="onEditConfirm($event)"

--- a/src/app/pages/admision/evaluacion-aspirantes/evaluacion-aspirantes.component.ts
+++ b/src/app/pages/admision/evaluacion-aspirantes/evaluacion-aspirantes.component.ts
@@ -107,6 +107,7 @@ export class EvaluacionAspirantesComponent implements OnInit {
   settings: any;
   columnas = [];
   criterio = [];
+  cantidad_aspirantes: number = 0;
 
   CampoControl = new FormControl('', [Validators.required]);
   Campo1Control = new FormControl('', [Validators.required]);
@@ -443,7 +444,29 @@ export class EvaluacionAspirantesComponent implements OnInit {
 
   async loadAspirantes() {
     return new Promise((resolve, reject) => {
-      this.inscripcionService.get('inscripcion?query=EstadoInscripcionId__Id:5,ProgramaAcademicoId:' +
+
+      this.sgaMidService.get('admision/getlistaaspirantespor?id_periodo='+this.periodo.Id+'&id_proyecto='+this.proyectos_selected+'&tipo_lista=2')
+      .subscribe(
+        (response: any) => {
+          if (response.Success && response.Status == "200") {
+            this.Aspirantes = response.Data;
+            this.cantidad_aspirantes = this.Aspirantes.length;
+            this.dataSource.load(this.Aspirantes);
+            resolve(this.Aspirantes)
+          }
+        },
+        (error: HttpErrorResponse) => {
+          reject(error)
+          Swal.fire({
+            icon: 'warning',
+            title: this.translate.instant('admision.titulo_no_aspirantes'),
+            text: this.translate.instant('admision.error_no_aspirantes'),
+            confirmButtonText: this.translate.instant('GLOBAL.aceptar'),
+          });
+        }
+      );
+      
+      /* this.inscripcionService.get('inscripcion?query=EstadoInscripcionId__Id:5,ProgramaAcademicoId:' +
         this.proyectos_selected + ',PeriodoId:' + this.periodo.Id + '&sortby=Id&order=asc').subscribe(
           (response: any) => {
             if (Object.keys(response[0]).length !== 0) {
@@ -484,7 +507,7 @@ export class EvaluacionAspirantesComponent implements OnInit {
             reject(error);
             this.popUpManager.showErrorToast(this.translate.instant('admision.error_cargar'));
           },
-        );
+        ); */
     });
 
   }

--- a/src/app/pages/admision/evaluacion-documentos-inscritos/evaluacion-documentos-inscritos.component.html
+++ b/src/app/pages/admision/evaluacion-documentos-inscritos/evaluacion-documentos-inscritos.component.html
@@ -1,4 +1,5 @@
-<nb-card>
+<nb-card [nbSpinner]="loading" nbSpinnerStatus="success" nbSpinnerSize="xxlarge"
+nbSpinnerMessage="{{ 'GLOBAL.cargando' | translate }}">
   <nb-card-body>
     <div class=col-12>
       <fieldset [ngClass]="{'fieldseter':true}" >
@@ -37,6 +38,9 @@
           </mat-form-field>
           <br/><br/>
 
+          <nb-card-body class="d-flex justify-content-around align-items-center">
+            <p>{{ 'admision.total_aspirantes' | translate }}: <b>{{cantidad_aspirantes}}</b></p>
+          </nb-card-body>
             <!--Tabla-->
             <nb-card-body>
               <div style="overflow: auto;">

--- a/src/app/pages/admision/listado_aspirantes/listado_aspirante.component.html
+++ b/src/app/pages/admision/listado_aspirantes/listado_aspirante.component.html
@@ -87,6 +87,7 @@
 
 <nb-card [hidden]="!show_listado" accent="info">
         <nb-card-header class="d-flex justify-content-around align-items-center">
+          <p>{{ 'admision.total_aspirantes' | translate }}: <b>{{cantidad_aspirantes}}</b></p>
           <p>{{ 'cupos.cupos_proyecto' | translate }}: <b>{{cuposProyecto}}</b></p>
           <p>{{ 'cupos.cupos_disponibles' | translate }} <b>{{(cuposProyecto - cuposAsignados )}}</b></p>
           <button class="btn btn-primary" (click)="admitirInscritos()" *ngIf="(cuposProyecto - cuposAsignados ) > 0" >
@@ -97,7 +98,8 @@
         </nb-card-header>
 </nb-card>
 
-<nb-card *ngIf="show_listado" accent="info">
+<nb-card *ngIf="show_listado" accent="info"  [nbSpinner]="loading" nbSpinnerStatus="success" nbSpinnerSize="xxlarge"
+nbSpinnerMessage="{{ 'GLOBAL.cargando' | translate }}">
         <nb-card-body>
             <div class="row">
                 <div class="col-12">

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -1598,7 +1598,8 @@
         "cambios_suite_inscripción": "Do you want to save changes to the Suite for the selected curricular project?",
         "guardado_existoso_suite": "Suite data has been successfully saved",
         "fallo_guardado_suite": "Something went wrong, the Suite could not be saved",
-        "info_uso_select_tags": "Select the necessary \"tags\" by clicking on the icons, these will be marked with a box. Those marked by the box will be visible to the applicant and you can make the required information mandatory or not by selecting the \"Required\" option."
+        "info_uso_select_tags": "Select the necessary \"tags\" by clicking on the icons, these will be marked with a box. Those marked by the box will be visible to the applicant and you can make the required information mandatory or not by selecting the \"Required\" option.",
+        "total_aspirantes": "Total applicants"
     },
     "cupos": {
         "aviso_periodo": "Period in which the admission quotas are defined",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -1630,7 +1630,8 @@
         "cambios_suite_inscripción": "¿Desea guardar cambios a la Suite para el proyecto curricular seleccionado?",
         "guardado_existoso_suite": "Los datos de la Suite se han guardado correctamente",
         "fallo_guardado_suite": "Algo salió mal, la Suite no ha podido ser guardada",
-        "info_uso_select_tags": "Seleccione los \"tags\" necesarios haciendo clic sobre los íconos, estos quedarán marcados con un recuadro. Los marcados por el recuadro serán visibles para el aspirante y puede hacer que la información requerida sea obligatoria o no seleccionando la opción \"Obligatorio\"."
+        "info_uso_select_tags": "Seleccione los \"tags\" necesarios haciendo clic sobre los íconos, estos quedarán marcados con un recuadro. Los marcados por el recuadro serán visibles para el aspirante y puede hacer que la información requerida sea obligatoria o no seleccionando la opción \"Obligatorio\".",
+        "total_aspirantes": "Total aspirantes"
     },
     "cupos": {
         "aviso_periodo": "Período en el cual se define los cupos de admisión",


### PR DESCRIPTION
- Ajuste aislado de consulta de aspirantes en módulo de admisiones, el flujo de consulta actualmente se realiza desde cliente, ahora se traslada a mid.
- La actual funcionalidad ya se encuentra desarrollada y probada en develop; se hace ajuste sobre master debido a otro desarrollo en proceso en develop.
- ⚠️  Se requiere llevar MID develop a master para consumir el recurso `GetListaAspirantesPor()` **pero antes:** https://github.com/udistrital/sga_mid/pull/496 faltaba limit=0 en unas consultas.