### PR TITLE
hotfix: se deshabilita función que cambia estado de aspirantes.

### DIFF
--- a/src/app/pages/asignacion_cupo/crud-asignacion_cupo/crud-asignacion_cupo.component.ts
+++ b/src/app/pages/asignacion_cupo/crud-asignacion_cupo/crud-asignacion_cupo.component.ts
@@ -283,7 +283,7 @@ export class CrudAsignacionCupoComponent implements OnInit, OnChanges {
               console.log(r)
               if (r !== null && r.Status === '200') {
                 this.loading = false;
-                this.cambiarestados();
+                //this.cambiarestados();
                 this.popUpManager.showSuccessAlert(this.translate.instant('GLOBAL.info_cupos') + ' ' + this.translate.instant('GLOBAL.confirmarCrear'));
                 this.showListadoAspirantes = true;
                 this.eventChange.emit(true);


### PR DESCRIPTION
- Se deshabilita función que cambia el estado de aspirantes inscritos a admitidos, queda pendiente revisar por qué se realiza este procedimiento.