### PR TITLE
feat: #1179 ajuste flujo asignacion correo usuarios existentes

### DIFF
--- a/src/app/@core/store/services/list.service.ts
+++ b/src/app/@core/store/services/list.service.ts
@@ -39,57 +39,75 @@ export class ListService {
   loading: boolean = false;
 
   public findGenero() {
-    this.store.select(<any>REDUCER_LIST.Genero).subscribe(
-      (list: any) => {
-        if (!list || list.length === 0) {
-          this.tercerosService.get('info_complementaria?query=GrupoInfoComplementariaId.Id:6,Activo:true&limit=0')
-            .subscribe(
-              (result: any[]) => {
-                this.addList(REDUCER_LIST.Genero, result);
-              },
-              error => {
-                this.addList(REDUCER_LIST.Genero, []);
-              },
-            );
-        }
-      },
-    );
+    return new Promise<void>((resolve, reject) => {
+      this.store.select(<any>REDUCER_LIST.Genero).subscribe(
+        (list: any) => {
+          if (!list || list.length === 0) {
+            this.tercerosService.get('info_complementaria?query=GrupoInfoComplementariaId.Id:6,Activo:true&limit=0')
+              .subscribe(
+                (result: any[]) => {
+                  this.addList(REDUCER_LIST.Genero, result);
+                  resolve();
+                },
+                error => {
+                  this.addList(REDUCER_LIST.Genero, []);
+                  reject();
+                },
+              );
+          } else {
+            resolve();
+          }
+        },
+      );
+    });
   }
 
   public findOrientacionSexual() {
-    this.store.select(<any>REDUCER_LIST.OrientacionSexual).subscribe(
-      (list: any) => {
-        if (!list || list.length === 0) {
-          this.tercerosService.get('info_complementaria?query=GrupoInfoComplementariaId.Id:1636,Activo:true&limit=0')
-            .subscribe(
-              (result: any[]) => {
-                this.addList(REDUCER_LIST.OrientacionSexual, result);
-              },
-              error => {
-                this.addList(REDUCER_LIST.OrientacionSexual, []);
-              },
-            );
-        }
-      },
-    );
+    return new Promise<void>((resolve, reject) => {
+      this.store.select(<any>REDUCER_LIST.OrientacionSexual).subscribe(
+        (list: any) => {
+          if (!list || list.length === 0) {
+            this.tercerosService.get('info_complementaria?query=GrupoInfoComplementariaId.Id:1636,Activo:true&limit=0')
+              .subscribe(
+                (result: any[]) => {
+                  this.addList(REDUCER_LIST.OrientacionSexual, result);
+                  resolve();
+                },
+                error => {
+                  this.addList(REDUCER_LIST.OrientacionSexual, []);
+                  reject();
+                },
+              );
+          } else {
+            resolve();
+          }
+        },
+      );
+    });
   }
 
   public findIdentidadGenero() {
-    this.store.select(<any>REDUCER_LIST.IdentidadGenero).subscribe(
-      (list: any) => {
-        if (!list || list.length === 0) {
-          this.tercerosService.get('info_complementaria?query=GrupoInfoComplementariaId.Id:1637,Activo:true&limit=0')
-            .subscribe(
-              (result: any[]) => {
-                this.addList(REDUCER_LIST.IdentidadGenero, result);
-              },
-              error => {
-                this.addList(REDUCER_LIST.IdentidadGenero, []);
-              },
-            );
-        }
-      },
-    );
+    return new Promise<void>((resolve, reject) => {
+      this.store.select(<any>REDUCER_LIST.IdentidadGenero).subscribe(
+        (list: any) => {
+          if (!list || list.length === 0) {
+            this.tercerosService.get('info_complementaria?query=GrupoInfoComplementariaId.Id:1637,Activo:true&limit=0')
+              .subscribe(
+                (result: any[]) => {
+                  this.addList(REDUCER_LIST.IdentidadGenero, result);
+                  resolve();
+                },
+                error => {
+                  this.addList(REDUCER_LIST.IdentidadGenero, []);
+                  reject();
+                },
+              );
+          } else {
+            resolve();
+          }
+        },
+      );
+    });
   }
 
   public findGrupoSanguineo() {
@@ -201,21 +219,27 @@ export class ListService {
   }
 
   public findEstadoCivil() {
-    this.store.select(<any>REDUCER_LIST.EstadoCivil).subscribe(
-      (list: any) => {
-        if (!list || list.length === 0) {
-          this.tercerosService.get('info_complementaria/?query=GrupoInfoComplementariaId.Id:2')
-            .subscribe(
-              (result: any[]) => {
-                this.addList(REDUCER_LIST.EstadoCivil, result);
-              },
-              error => {
-                this.addList(REDUCER_LIST.EstadoCivil, []);
-              },
-            );
-        }
-      },
-    );
+    return new Promise<void>((resolve, reject) => {
+      this.store.select(<any>REDUCER_LIST.EstadoCivil).subscribe(
+        (list: any) => {
+          if (!list || list.length === 0) {
+            this.tercerosService.get('info_complementaria/?query=GrupoInfoComplementariaId.Id:2')
+              .subscribe(
+                (result: any[]) => {
+                  this.addList(REDUCER_LIST.EstadoCivil, result);
+                  resolve();
+                },
+                error => {
+                  this.addList(REDUCER_LIST.EstadoCivil, []);
+                  reject();
+                },
+              );
+          } else {
+            resolve();
+          }
+        },
+      );
+    });
   }
 
   public findTipoPoblacion() {
@@ -551,21 +575,27 @@ export class ListService {
   }
 
   public findTipoIdentificacion() {
-    this.store.select(<any>REDUCER_LIST.TipoIdentificacion).subscribe(
-      (list: any) => {
-        if (!list || list.length === 0) {
-          this.tercerosService.get('tipo_documento/?query=Activo:true&limit=0')
-            .subscribe(
-              (result: any[]) => {
-                this.addList(REDUCER_LIST.TipoIdentificacion, result);
-              },
-              error => {
-                this.addList(REDUCER_LIST.TipoIdentificacion, []);
-              },
-            );
-        }
-      },
-    );
+    return new Promise<void>((resolve, reject) => {
+      this.store.select(<any>REDUCER_LIST.TipoIdentificacion).subscribe(
+        (list: any) => {
+          if (!list || list.length === 0) {
+            this.tercerosService.get('tipo_documento/?query=Activo:true&limit=0')
+              .subscribe(
+                (result: any[]) => {
+                  this.addList(REDUCER_LIST.TipoIdentificacion, result);
+                  resolve();
+                },
+                error => {
+                  this.addList(REDUCER_LIST.TipoIdentificacion, []);
+                  reject();
+                },
+              );
+          } else {
+            resolve();
+          }
+        },
+      );
+    });
   }
 
   public findTipoProyecto() {

--- a/src/app/@core/utils/utilidades.service.ts
+++ b/src/app/@core/utils/utilidades.service.ts
@@ -80,4 +80,12 @@ export class UtilidadesService {
     return ObjetMetadatos;
   }
 
+  static hardCopy(Objeto: Object): Object {
+    return JSON.parse(JSON.stringify(Objeto));
+  }
+
+  static ListaPatrones = {
+    correo: /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/,
+  }
+
 }

--- a/src/app/managers/popUpManager.ts
+++ b/src/app/managers/popUpManager.ts
@@ -76,9 +76,10 @@ export class PopUpManager {
     public showPopUpGeneric(title, text, type, cancelar): Promise<any> {
         const opt: any = {
             title: title,
-            text: text,
+            html: text,
             icon: type,
             showCancelButton: cancelar,
+            allowOutsideClick: !cancelar,
             confirmButtonText: this.translate.instant('GLOBAL.aceptar'),
             cancelButtonText: this.translate.instant('GLOBAL.cancelar'),
         };

--- a/src/app/pages/inscripcion/crud-inscripcion_multiple/crud-inscripcion_multiple.component.ts
+++ b/src/app/pages/inscripcion/crud-inscripcion_multiple/crud-inscripcion_multiple.component.ts
@@ -135,6 +135,7 @@ export class CrudInscripcionMultipleComponent implements OnInit {
   return() {
     this.showInscription = true;
     sessionStorage.setItem('EstadoInscripcion', 'false');
+    this.loadInfoInscripcion();
   }
 
   public loadInfoPersona(): void {

--- a/src/app/pages/inscripcion/inscripcion_general/inscripcion_general.component.ts
+++ b/src/app/pages/inscripcion/inscripcion_general/inscripcion_general.component.ts
@@ -1188,6 +1188,9 @@ export class InscripcionGeneralComponent implements OnInit, OnChanges {
         this.show_prod = false;
         this.show_desc = false;
         break;
+      case 'salir_preinscripcion':
+        this.activateTab();
+        break;
       default:
         this.show_info = false;
         this.show_docu = false;

--- a/src/app/pages/inscripcion/perfil/perfil.component.ts
+++ b/src/app/pages/inscripcion/perfil/perfil.component.ts
@@ -91,6 +91,7 @@ export class PerfilComponent implements OnInit {
         .then(() => {
           this.imprimir = false;
           this.loading = false;
+          this.editar(null, 'salir_preinscripcion')
         })
     }
 

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -231,6 +231,7 @@
         "placeholder_periodo": "E.g.: I,II,III",
         "tiporecurrencia": "Recurrence type",
         "crear_info_persona": "Are you sure you want to save personal information?\n You will not be able to modify it after accepting.",
+        "actualizar_info_persona": "Are you sure you want to update personal information?\n You will not be able to modify it after accepting.",
         "placeholder_tiporecurrencia": "E.g.: Recurrence type",
         "codigoabreviacion": "abbreviation code",
         "placeholder_codigoabreviacion": "E.g.: abbreviation code",
@@ -1343,7 +1344,10 @@
         "no_cambiar_inscripcion_solicitada": "It is not possible to change the status to Enrollment Requested",
         "editar_estado_iscripcion": "Edit Enrollment Status",
         "sin_telefono": "No contact number, please enter a phone number",
-        "mensaje_100_inscripcion": "Applicant, you already have 100% of the required documentation, do not forget to press the \"Register\" button to continue with the process."
+        "mensaje_100_inscripcion": "Applicant, you already have 100% of the required documentation, do not forget to press the \"Register\" button to continue with the process.",
+        "ya_existe_usuarioCorreo": "The mail found does not match the one in the current session! Press ACCEPT to update it, or press CANCEL to log out and enter with the previous email.",
+        "correo_anterior": "Previous email",
+        "correo_actual": "Current email"
     },
     "reingreso": {
         "reingreso_no_registrado": "Re-entry request not created",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -245,6 +245,7 @@
         "tiporecurrencia": "tipo recurrencia",
         "info_caracteristica": "Información característica",
         "crear_info_persona": "¿Está seguro que desea guardar la información personal?\n No podrá modificarla después de aceptar.",
+        "actualizar_info_persona": "¿Está seguro que desea actualizar la información personal?\n No podrá modificarla después de aceptar.",
         "placeholder_tiporecurrencia": "ej: tipo recurrencia",
         "codigoabreviacion": "código abreviación",
         "placeholder_codigoabreviacion": "ej: código abreviación",
@@ -1379,7 +1380,10 @@
         "no_cambiar_inscripcion_solicitada": "No es posible cambiar el estado a Inscripción Solicitada",
         "editar_estado_iscripcion": "Editar estado de inscripción",
         "sin_telefono": "Sin número de contacto, por favor ingrese un número de telefono",
-        "mensaje_100_inscripcion": "Aspirante, ya cuenta con el 100% de la documentación requerida, no olvide presionar el botón \"Inscribirse\" para continuar con el proceso."
+        "mensaje_100_inscripcion": "Aspirante, ya cuenta con el 100% de la documentación requerida, no olvide presionar el botón \"Inscribirse\" para continuar con el proceso.",
+        "ya_existe_usuarioCorreo": "¡El correo encontrado no coincide con el de la sesión actual! Presione ACEPTAR para actualizarlo, o presione CANCELAR para cerrar sesión e ingresar con el correo anterior.",
+        "correo_anterior": "Correo anterior",
+        "correo_actual": "Correo actual"
     },
     "reingreso": {
         "reingreso_no_registrado": "Solicitud de reingreso no registrada",


### PR DESCRIPTION
- https://github.com/udistrital/sga_cliente/issues/1179
- Se ajusta la asignación de información cuando un aspirante nuevo para WSO2 ya tiene información de tercero:
  - Ahora cuando se consulta por no. identificación se revisa si ya tiene correo como usuario, si no lo es se sustituye por el nuevo correo.
  - Pero, si existe correo en el campo usuario, aparece modal sugiriendo sobreescribir o salir para ingresar con el otro correo.

Otras mejoras:

- Se ajusta carga de listas (estado civil, sexo, genero, ...) para que mediante promesa esperen a que todas carguen antes de pedir la información del usuario.
- Se ajusta visualización de porcentaje de avance, ya no se completa al 50% si no se ha guardado o actualizado la información de tercero.
- Se ajusta visualización del formulacio cuando se guarda información, los campos antes quedaban disponibles para editar.
- Se ajusta corrección horaria a fechas, faltaba añadirla a la carga de información cuando existe persona
- Se añade carga nuevamente de la tabla de los recibos de inscripción cada vez que sale de alguna suite en particular, esto para que cuando presione inscribirse se actualicen los datos.
- Se añade también que despues de imprimir automáticamente vuelva a esta tabla, si se da regresar en la vista (resumen inscripcion) va a la suite pudiendo editar la información.

- se hace un ajuste en mid para incluir el teléfono en unos casos que hacía falta. https://github.com/udistrital/sga_mid/pull/502