### PR TITLE
feat: #1180 Ajuste visualización resumen inscripcion usando Suite inscripción

### DIFF
--- a/src/app/pages/admision/evaluacion-documentos-inscritos/evaluacion-documentos-inscritos.component.html
+++ b/src/app/pages/admision/evaluacion-documentos-inscritos/evaluacion-documentos-inscritos.component.html
@@ -65,7 +65,7 @@ nbSpinnerMessage="{{ 'GLOBAL.cargando' | translate }}">
             <button (click)="activateTab()" class="btn btn-info btn-sm"> <i class="nb-arrow-dropleft"></i> {{ 'GLOBAL.regresar' | translate }}</button>
           </div>
           <div class="text-center">
-            <ngx-perfil [en_revision]="true" info_persona_id="{{info_persona_id}}" inscripcion_id="{{inscripcion_id}}"
+            <ngx-perfil [SuiteTags]="tagsObject" [en_revision]="true" info_persona_id="{{info_persona_id}}" inscripcion_id="{{inscripcion_id}}"
               (revisar_doc)="revisarDocumento($event)">
             </ngx-perfil>
           </div>

--- a/src/app/pages/admision/evaluacion-documentos-inscritos/evaluacion-documentos-inscritos.component.ts
+++ b/src/app/pages/admision/evaluacion-documentos-inscritos/evaluacion-documentos-inscritos.component.ts
@@ -19,6 +19,8 @@ import { InvitacionTemplate } from '../../../@core/data/models/correo/invitacion
 import Swal from 'sweetalert2';
 import { PivotDocument } from '../../../@core/utils/pivot_document.service';
 import { SgaMidService } from '../../../@core/data/sga_mid.service';
+import { EvaluacionInscripcionService } from '../../../@core/data/evaluacion_inscripcion.service';
+import { TAGS_INSCRIPCION_PROGRAMA } from '../def_suite_inscrip_programa/def_tags_por_programa';
 
 
 @Component({
@@ -47,6 +49,7 @@ export class EvaluacionDocumentosInscritosComponent implements OnInit {
   cantidad_admitidos: number = 0;
   cantidad_inscritos: number = 0;
   mostrarConteos: boolean = false;
+  tagsObject = {...TAGS_INSCRIPCION_PROGRAMA};
 
   periodos = [];
   proyectos = [];
@@ -65,6 +68,7 @@ export class EvaluacionDocumentosInscritosComponent implements OnInit {
     private googleMidService: GoogleService,
     private pivotDocument: PivotDocument,
     private sgaMidService: SgaMidService,
+    private evaluacionInscripcionService: EvaluacionInscripcionService,
   ) {
     this.invitacion = new Invitacion();
     this.invitacionTemplate = new InvitacionTemplate();
@@ -83,6 +87,7 @@ export class EvaluacionDocumentosInscritosComponent implements OnInit {
         this.revisarDocumento(document)
       }
     })
+    localStorage.setItem("goToEdit", String(false));
   }
 
   async loadData() {
@@ -241,23 +246,38 @@ export class EvaluacionDocumentosInscritosComponent implements OnInit {
             this.inscripcion_id = event.data['Credencial'];
             this.inscripcionService.get('inscripcion?query=Id:' + this.inscripcion_id).subscribe(
               (resp: any[]) => {
+                this.evaluacionInscripcionService.get('tags_por_dependencia?query=Activo:true,PeriodoId:'+this.periodo.Id+',DependenciaId:'+this.proyectos_selected+',TipoInscripcionId:'+resp[0].TipoInscripcionId.Id)
+                  .subscribe((respSuite: any) => {
+                    if (respSuite != null && respSuite.Status == '200') {
+                      if (Object.keys(respSuite.Data[0]).length > 0) {
+                        this.tagsObject = JSON.parse(respSuite.Data[0].ListaTags);
 
-                this.info_persona_id = response[0].TerceroId.Id;
-                this.pivotDocument.updateInfo({
-                  TerceroId: response[0].TerceroId.Id,
-                  IdInscripcion: event.data['Credencial'],
-                  ProgramaAcademicoId: this.proyectos_selected.toString(),
-                  ProgramaAcademico: res.Nombre,
-                  IdPeriodo: this.periodo.Id
-                })
-                sessionStorage.setItem('TerceroId', response[0].TerceroId.Id);
-                sessionStorage.setItem('IdInscripcion', event.data['Credencial']);
-                sessionStorage.setItem('ProgramaAcademicoId', this.proyectos_selected.toString());
-                sessionStorage.setItem('ProgramaAcademico', res.Nombre);
-                sessionStorage.setItem('IdPeriodo', this.periodo.Id);
-                sessionStorage.setItem('IdTipoInscripcion', resp[0].TipoInscripcionId.Id);
-                this.showProfile = false;
+                        this.info_persona_id = response[0].TerceroId.Id;
+                        this.pivotDocument.updateInfo({
+                          TerceroId: response[0].TerceroId.Id,
+                          IdInscripcion: event.data['Credencial'],
+                          ProgramaAcademicoId: this.proyectos_selected.toString(),
+                          ProgramaAcademico: res.Nombre,
+                          IdPeriodo: this.periodo.Id
+                        })
+                        sessionStorage.setItem('TerceroId', response[0].TerceroId.Id);
+                        sessionStorage.setItem('IdInscripcion', event.data['Credencial']);
+                        sessionStorage.setItem('ProgramaAcademicoId', this.proyectos_selected.toString());
+                        sessionStorage.setItem('ProgramaAcademico', res.Nombre);
+                        sessionStorage.setItem('IdPeriodo', this.periodo.Id);
+                        sessionStorage.setItem('IdTipoInscripcion', resp[0].TipoInscripcionId.Id);
+                        this.showProfile = false;
 
+                      } else {
+                        this.popUpManager.showAlert(this.translate.instant('inscripcion.preinscripcion'), this.translate.instant('admision.no_tiene_suite'));
+                      }
+                    } else {
+                      this.popUpManager.showAlert(this.translate.instant('inscripcion.preinscripcion'), this.translate.instant('admision.no_tiene_suite'));
+                    }
+                  },
+                  (error: HttpErrorResponse) => {
+                    this.popUpManager.showErrorToast(this.translate.instant('admision.error_cargar'));
+                  });
               },
               error => {
                 this.popUpManager.showErrorToast(this.translate.instant('admision.error_cargar'));

--- a/src/app/pages/inscripcion/inscripcion_general/inscripcion_general.component.html
+++ b/src/app/pages/inscripcion/inscripcion_general/inscripcion_general.component.html
@@ -717,7 +717,7 @@
 
     <!-- <div [hidden]="!show_profile"> -->
     <div *ngIf="show_profile">
-        <ngx-perfil [en_revision]="false" (revisar_doc)="revisarDocumento($event)" (url_editar)="perfil_editar($event)" info_persona_id="{{this.info_persona_id}}"
+        <ngx-perfil [SuiteTags]="tagsObject" [en_revision]="false" (revisar_doc)="revisarDocumento($event)" (url_editar)="perfil_editar($event)" info_persona_id="{{this.info_persona_id}}"
             inscripcion_id="{{this.inscripcion_id}}" imprimir="{{this.imprimir}}">
         </ngx-perfil>
     </div>

--- a/src/app/pages/inscripcion/perfil/perfil.component.html
+++ b/src/app/pages/inscripcion/perfil/perfil.component.html
@@ -6,7 +6,7 @@
                   nbSpinnerMessage="{{ 'GLOBAL.cargando' | translate }}">
       <div>
         <div class="row" [hidden]="imprimir">
-          <div class="col-md-11 text-center">
+          <div [ngClass]="!en_revision ? 'col-md-11 text-center' : 'col-md-12 text-center'">
             <h1>{{ 'inscripcion.perfil' | translate }}</h1>
           </div>
           <div class="col-md-1 float-right" *ngIf="!en_revision">
@@ -29,12 +29,13 @@
           </div>
         </div>
       </div>
-      <div class="row">
+      <div class="row" *ngIf="suiteLoaded">
         <ngx-view-inscripcion class="col-md-12"></ngx-view-inscripcion>
         <ngx-view-info-persona (url_editar)="editar($event,'info_persona')"
                                (revisar_doc)="abrirDocumento($event)"
                                persona_id="{{info_persona_id}}"
-                               class="col-md-12">
+                               class="col-md-12"
+                               *ngIf="SuiteTags.info_persona.selected">
         </ngx-view-info-persona>
         <!--<ngx-view-info-caracteristica
           (url_editar)="editar($event,'info_caracteristica')"
@@ -45,17 +46,20 @@
         <ngx-view-formacion-academica (url_editar)="editar($event,'formacion_academica')"
                                       (revisar_doc)="abrirDocumento($event)"
                                       persona_id="{{info_persona_id}}"
-                                      class="col-md-12">
+                                      class="col-md-12"
+                                      *ngIf="SuiteTags.formacion_academica.selected">
         </ngx-view-formacion-academica>
         <ngx-view-idiomas (url_editar)="editar($event,'formacion_academica')"
                           persona_id="{{info_persona_id}}"
                           inscripcion_id="{{info_inscripcion_id}}"
-                          class="col-md-12">
+                          class="col-md-12"
+                          *ngIf="SuiteTags.idiomas.selected">
         </ngx-view-idiomas>
         <ngx-view-experiencia-laboral (url_editar)="editar($event,'experiencia_laboral')"
                                       (revisar_doc)="abrirDocumento($event)"
                                       persona_id="{{info_persona_id}}"
-                                      class="col-md-12">
+                                      class="col-md-12"
+                                      *ngIf="SuiteTags.experiencia_laboral.selected">
         </ngx-view-experiencia-laboral>
         <!--<ngx-view-libro (url_editar)="editar($event,'default')"
           persona_id="{{info_persona_id}}" class="col-md-12"></ngx-view-libro>
@@ -74,26 +78,30 @@
         <ngx-view-produccion-academica (url_editar)="editar($event,'produccion_academica')"
                                       (revisar_doc)="abrirDocumento($event)"
                                        persona_id="{{info_persona_id}}"
-                                       class="col-md-12">
+                                       class="col-md-12"
+                                       *ngIf="SuiteTags.produccion_academica.selected">
         </ngx-view-produccion-academica>
         <ngx-view-descuento-academico (url_editar)="editar($event,'descuento_matricula')"
                                       (revisar_doc)="abrirDocumento($event)"
                                       inscripcion_id="{{info_inscripcion_id}}"
                                       persona_id="{{info_persona_id}}"
-                                      class="col-md-12">
+                                      class="col-md-12"
+                                      *ngIf="SuiteTags.descuento_matricula.selected">
         </ngx-view-descuento-academico>
         <ngx-view-propuesta-grado (url_editar)="editar($event,'propuesta_grado')"
                                   (listo)="activarImprimir($event)"
                                   (revisar_doc)="abrirDocumento($event)"
                                   inscripcion_id="{{info_inscripcion_id}}"
                                   persona_id="{{info_persona_id}}"
-                                  class="col-md-12">
+                                  class="col-md-12"
+                                  *ngIf="SuiteTags.propuesta_grado.selected">
         </ngx-view-propuesta-grado>
         <ngx-view-documento-programa (url_editar)="editar($event, 'documento_programa')"
                                      (revisar_doc)="abrirDocumento($event)"
                                      inscripcion_id="{{info_inscripcion_id}}"
                                      persona_id="{{info_persona_id}}"
-                                     class="col-md-12">
+                                     class="col-md-12"
+                                     *ngIf="SuiteTags.documento_programa.selected">
         </ngx-view-documento-programa>
 
         <div class="col-md-12" *ngIf="en_revision">

--- a/src/app/pages/inscripcion/perfil/perfil.component.ts
+++ b/src/app/pages/inscripcion/perfil/perfil.component.ts
@@ -33,6 +33,9 @@ export class PerfilComponent implements OnInit {
 
   @Input('imprimir') imprimir: boolean = false;
 
+  @Input('SuiteTags') SuiteTags: any;
+
+  suiteLoaded: boolean = false;
   // tslint:disable-next-line: no-output-rename
   @Output('url_editar') url_editar: EventEmitter<boolean> = new EventEmitter();
 
@@ -46,7 +49,7 @@ export class PerfilComponent implements OnInit {
     private zipManagerService: ZipManagerService) {
     this.translate.onLangChange.subscribe((event: LangChangeEvent) => {
     });
-    this.loading = true;
+    //this.loading = true;
   }
 
   useLanguage(language: string) {
@@ -64,6 +67,7 @@ export class PerfilComponent implements OnInit {
   ngOnChanges() {
     this.imprimir = this.imprimir.toString() === 'true';
     this.en_revision = this.en_revision.toString() === 'true';
+    this.manageSuiteTags(this.SuiteTags);
   }
 
   ifFinishLoaded(event) {
@@ -82,6 +86,13 @@ export class PerfilComponent implements OnInit {
     return finishLoaded;
   }
 
+  manageSuiteTags(Suite) {
+    if (Suite == undefined) {
+      this.suiteLoaded = false;
+    } else {
+      this.suiteLoaded = true;
+    }
+  }
 
   async activarImprimir(event: boolean) {
     const ifLoaded = await this.ifFinishLoaded(event)


### PR DESCRIPTION
- https://github.com/udistrital/sga_cliente/issues/1180
- Ahora la visualización en _(componente perfil)_ o resumen de inscripción es dinámica, unicamente se carga la información relacionada a los tags seleccionados.
- Aplica tanto para vista de aspirante, como para admisiones.
- Sin embargo, admisiones no contaba con la consulta de la suite, por tanto se añade y se inyecta al componente