### PR TITLE
fix: capturar si fecha Nacimiento/Expedicion nulas en consulta infoPersona

### DIFF
--- a/src/app/pages/info_persona/crud-info_persona/crud-info_persona.component.ts
+++ b/src/app/pages/info_persona/crud-info_persona/crud-info_persona.component.ts
@@ -121,13 +121,19 @@ export class CrudInfoPersonaComponent implements OnInit {
             this.datosEncontrados = {...res}
             const files = []
             this.formInfoPersona.btn = '';
-            this.formInfoPersona.campos[this.getIndexForm('Genero')].valor = temp.Genero;
+            if (temp.Genero.Nombre != "NO APLICA") {
+              this.formInfoPersona.campos[this.getIndexForm('Genero')].valor = temp.Genero;
+            }
             this.formInfoPersona.campos[this.getIndexForm('EstadoCivil')].valor = temp.EstadoCivil;
             this.formInfoPersona.campos[this.getIndexForm('TipoIdentificacion')].valor = temp.TipoIdentificacion;
-            temp.FechaNacimiento = temp.FechaNacimiento.replace("T00:00:00Z", "T05:00:00Z");
-            temp.FechaExpedicion = temp.FechaExpedicion.replace("T00:00:00Z", "T05:00:00Z");
-            this.formInfoPersona.campos[this.getIndexForm('FechaNacimiento')].valor = moment(temp.FechaNacimiento,"YYYY-MM-DDTHH:mm:ss").tz("America/Bogota").toDate();
-            this.formInfoPersona.campos[this.getIndexForm('FechaExpedicion')].valor = moment(temp.FechaExpedicion,"YYYY-MM-DDTHH:mm:ss").tz("America/Bogota").toDate();
+            if (temp.FechaNacimiento != null) {
+              temp.FechaNacimiento = temp.FechaNacimiento.replace("T00:00:00Z", "T05:00:00Z");
+              this.formInfoPersona.campos[this.getIndexForm('FechaNacimiento')].valor = moment(temp.FechaNacimiento,"YYYY-MM-DDTHH:mm:ss").tz("America/Bogota").toDate();
+            }
+            if (temp.FechaExpedicion != null) {
+              temp.FechaExpedicion = temp.FechaExpedicion.replace("T00:00:00Z", "T05:00:00Z");
+              this.formInfoPersona.campos[this.getIndexForm('FechaExpedicion')].valor = moment(temp.FechaExpedicion,"YYYY-MM-DDTHH:mm:ss").tz("America/Bogota").toDate();
+            }
             this.formInfoPersona.campos.splice(this.getIndexForm('VerificarNumeroIdentificacion'),1);
             this.formInfoPersona.campos.forEach(campo => {
               campo.deshabilitar = true;
@@ -168,10 +174,17 @@ export class CrudInfoPersonaComponent implements OnInit {
           this.loading = false;
           this.info_info_persona = res[0];
           this.datosEncontrados = {...res[0]};
-          res[0].FechaNacimiento = res[0].FechaNacimiento.replace("T00:00:00Z", "T05:00:00Z");
-          res[0].FechaExpedicion = res[0].FechaExpedicion.replace("T00:00:00Z", "T05:00:00Z");
-          this.formInfoPersona.campos[this.getIndexForm('FechaNacimiento')].valor = moment(res[0].FechaNacimiento,"YYYY-MM-DDTHH:mm:ss").tz("America/Bogota").toDate();
-          this.formInfoPersona.campos[this.getIndexForm('FechaExpedicion')].valor = moment(res[0].FechaExpedicion,"YYYY-MM-DDTHH:mm:ss").tz("America/Bogota").toDate();
+          if (res[0].FechaNacimiento != null) {
+            res[0].FechaNacimiento = res[0].FechaNacimiento.replace("T00:00:00Z", "T05:00:00Z");
+            this.formInfoPersona.campos[this.getIndexForm('FechaNacimiento')].valor = moment(res[0].FechaNacimiento,"YYYY-MM-DDTHH:mm:ss").tz("America/Bogota").toDate();
+          }
+          if (res[0].FechaExpedicion != null) {
+            res[0].FechaExpedicion = res[0].FechaExpedicion.replace("T00:00:00Z", "T05:00:00Z");
+            this.formInfoPersona.campos[this.getIndexForm('FechaExpedicion')].valor = moment(res[0].FechaExpedicion,"YYYY-MM-DDTHH:mm:ss").tz("America/Bogota").toDate();
+          }
+          if (res[0].Genero.Nombre != "NO APLICA") {
+            this.formInfoPersona.campos[this.getIndexForm('Genero')].valor = res[0].Genero;
+          }
           
           this.formInfoPersona.campos.splice(this.getIndexForm('VerificarNumeroIdentificacion'),1);
 
@@ -429,7 +442,7 @@ export class CrudInfoPersonaComponent implements OnInit {
   public loadLists() {
     this.store.select((state) => state).subscribe(
       (list) => {
-        this.formInfoPersona.campos[this.getIndexForm('Genero')].opciones = list.listGenero[0];
+        this.formInfoPersona.campos[this.getIndexForm('Genero')].opciones = (<any>list.listGenero[0]).filter((g) => g.Nombre != "NO APLICA");
         this.formInfoPersona.campos[this.getIndexForm('EstadoCivil')].opciones = list.listEstadoCivil[0];
         this.formInfoPersona.campos[this.getIndexForm('TipoIdentificacion')].opciones = list.listTipoIdentificacion[0];
         this.formInfoPersona.campos[this.getIndexForm('OrientacionSexual')].opciones = list.listOrientacionSexual[0];


### PR DESCRIPTION
- Se revisa tanto en consultas MID [ persona/consultar_persona,  persona/existe_persona ] si fechas Nacimiento o Expedición están nulas, puede que ya exista información de tercero incompleta.
  - El error surgía al tratar de dar formato de fecha a un dato nulo, ahora solo se da formato si existe algún valor de fecha, de lo contrario el campo queda vacío y con opción para que el usuario diligencie y guarde cambios.
- También, en Género(Sexo) se deja vacío si el campo existente es NO APLICA, como persona natural debe tener un género; se asegura que el select de género no cargue la opción no aplica.