### PR TITLE
feat: #1237 asignación dependencia automáticamente segun tercero

### DIFF
--- a/src/app/pages/admision/asignacion_cupos/asignacion_cupos.component.html
+++ b/src/app/pages/admision/asignacion_cupos/asignacion_cupos.component.html
@@ -40,7 +40,7 @@
                                 [(ngModel)]="proyectos_selected"
                                 (selectionChange)="perfil_editar('info_cupos')"
                                 [disabled]='selectprograma'>
-                        <mat-option *ngFor="let item of proyectos" [value]="item">
+                        <mat-option *ngFor="let item of proyectos" [value]="item" [disabled]="!item.Id">
                             {{item.Nombre}}
                         </mat-option>
                     </mat-select>

--- a/src/app/pages/admision/asignar_documentos_descuentos/asignar_documentos_descuentos.component.html
+++ b/src/app/pages/admision/asignar_documentos_descuentos/asignar_documentos_descuentos.component.html
@@ -36,7 +36,7 @@ nbSpinnerMessage="{{ 'GLOBAL.cargando' | translate }}">
                               [(ngModel)]="proyectos_selected"
                               (selectionChange)="loadTipoInscripcion()">
                               <!-- (selectionChange)="loadCriterios()" -->
-                    <mat-option *ngFor="let item of proyectos" [value]="item.Id">{{item.Nombre}}</mat-option>
+                    <mat-option *ngFor="let item of proyectos" [value]="item.Id" [disabled]="!item.Id">{{item.Nombre}}</mat-option>
                   </mat-select>
                   <mat-error *ngIf="Campo1Control.hasError('required')">
                     {{ 'documento_proyecto.erro_selec_proyecto' | translate }}

--- a/src/app/pages/admision/asignar_documentos_descuentos/asignar_documentos_descuentos.component.ts
+++ b/src/app/pages/admision/asignar_documentos_descuentos/asignar_documentos_descuentos.component.ts
@@ -10,6 +10,9 @@ import { SelectDocumentoProyectoComponent } from '../../documento_proyecto/selec
 import { SelectDescuentoProyectoComponent } from '../../descuento_proyecto/select-descuento-proyecto/select-descuento-proyecto.component';
 import { NbDialogService } from '@nebular/theme';
 import { InscripcionService } from '../../../@core/data/inscripcion.service';
+import { UserService } from '../../../@core/data/users.service';
+import { SgaMidService } from '../../../@core/data/sga_mid.service';
+import { ImplicitAutenticationService } from '../../../@core/utils/implicit_autentication.service';
 
 @Component({
   selector: 'ngx-asignar_documentos_descuentos',
@@ -44,7 +47,10 @@ export class AsignarDocumentosDescuentosComponent implements OnInit {
     private dialogService: NbDialogService,
     private projectService: ProyectoAcademicoService,
     private popUpManager: PopUpManager,
-    private inscripcionService: InscripcionService) {
+    private inscripcionService: InscripcionService,
+    private userService: UserService,
+    private sgaMidService: SgaMidService,
+    private autenticationService: ImplicitAutenticationService,) {
     this.translate = translate;
     this.translate.onLangChange.subscribe((event: LangChangeEvent) => { });
     this.loadData();
@@ -127,8 +133,32 @@ export class AsignarDocumentosDescuentosComponent implements OnInit {
       this.loading = true;
       this.projectService.get('proyecto_academico_institucion?limit=0').subscribe(
         (response: any) => {
-          this.proyectos = <any[]>response.filter(
-            proyecto => this.filtrarProyecto(proyecto),
+          this.autenticationService.getRole().then(
+            (rol: Array <String>) => {
+              let r = rol.find(role => (role == "ADMIN_SGA")); // rol admin, pendiente vice
+              if (r) {
+                this.proyectos = <any[]>response.filter(
+                  proyecto => this.filtrarProyecto(proyecto),
+                );
+              } else {
+                const id_tercero = this.userService.getPersonaId();
+                this.sgaMidService.get('admision/dependencia_vinculacion_tercero/'+id_tercero).subscribe(
+                  (respDependencia: any) => {
+                    const dependencias = <Number[]>respDependencia.Data.DependenciaId;
+                    this.proyectos = <any[]>response.filter(
+                      proyecto => dependencias.includes(proyecto.Id)
+                    );
+                    if (dependencias.length > 1) {
+                      this.popUpManager.showAlert(this.translate.instant('GLOBAL.info'),this.translate.instant('admision.multiple_vinculacion')+". "+this.translate.instant('GLOBAL.comunicar_OAS_error'));
+                      this.proyectos.forEach(p => { p.Id = undefined })
+                    }
+                  },
+                  (error: any) => {
+                    this.popUpManager.showErrorAlert(this.translate.instant('admision.no_vinculacion_no_rol')+". "+this.translate.instant('GLOBAL.comunicar_OAS_error'));
+                  }
+                );
+              }
+            }
           );
           this.loading = false;
         },

--- a/src/app/pages/admision/criterio_admision/criterio_admision.component.html
+++ b/src/app/pages/admision/criterio_admision/criterio_admision.component.html
@@ -42,7 +42,7 @@
                                 [(ngModel)]="proyectos_selected"
                                 (selectionChange)="activeCriterios()">
                         <mat-option>--Seleccionar--</mat-option>
-                        <mat-option *ngFor="let project of proyectos" [value]="project.Id">{{ project.Nombre }}</mat-option>
+                        <mat-option *ngFor="let project of proyectos" [value]="project.Id" [disabled]="!project.Id">{{ project.Nombre }}</mat-option>
                     </mat-select>
                     <mat-error *ngIf="Campo1Control.hasError('required')">
                       {{ 'admision.erro_selec_proyecto' | translate }}

--- a/src/app/pages/admision/def_suite_inscrip_programa/def-suite-inscrip-programa.component.html
+++ b/src/app/pages/admision/def_suite_inscrip_programa/def-suite-inscrip-programa.component.html
@@ -30,7 +30,7 @@
                         <mat-label>{{ 'admision.proyecto' | translate }}:</mat-label>
                         <mat-select [(ngModel)]="proyecto" (selectionChange)="cambioProyecto(proyecto)">
                             <mat-option> {{ 'GLOBAL.seleccionar' | translate }} </mat-option>
-                            <mat-option *ngFor="let item of proyectosFiltered" [value]="item.Id"> {{item.Nombre}} </mat-option>
+                            <mat-option *ngFor="let item of proyectosFiltered" [value]="item.Id" [disabled]="!item.Id"> {{item.Nombre}} </mat-option>
                         </mat-select>
                     </mat-form-field>
 

--- a/src/app/pages/admision/evaluacion-aspirantes/evaluacion-aspirantes.component.html
+++ b/src/app/pages/admision/evaluacion-aspirantes/evaluacion-aspirantes.component.html
@@ -35,7 +35,7 @@
                               [(ngModel)]="proyectos_selected"
                               (selectionChange)="loadCriterios()"
                               [disabled]='selectprograma'>
-                    <mat-option *ngFor="let item of proyectos" [value]="item.Id">{{item.Nombre}}</mat-option>
+                    <mat-option *ngFor="let item of proyectos" [value]="item.Id" [disabled]="!item.Id">{{item.Nombre}}</mat-option>
                   </mat-select>
                   <mat-error *ngIf="Campo1Control.hasError('required')">
                     {{ 'admision.erro_selec_proyecto' | translate }}

--- a/src/app/pages/admision/evaluacion-aspirantes/evaluacion-aspirantes.component.ts
+++ b/src/app/pages/admision/evaluacion-aspirantes/evaluacion-aspirantes.component.ts
@@ -16,6 +16,7 @@ import Swal from 'sweetalert2';
 import { FormControl, Validators } from '@angular/forms';
 import { PopUpManager } from '../../../managers/popUpManager';
 import { CheckboxAssistanceComponent } from '../../../@theme/components/checkbox-assistance/checkbox-assistance.component';
+import { ImplicitAutenticationService } from '../../../@core/utils/implicit_autentication.service';
 
 @Component({
   selector: 'evaluacion-aspirantes',
@@ -122,7 +123,8 @@ export class EvaluacionAspirantesComponent implements OnInit {
     private tercerosService: TercerosService,
     private sgaMidService: SgaMidService,
     private popUpManager: PopUpManager,
-    private inscripcionService: InscripcionService) {
+    private inscripcionService: InscripcionService,
+    private autenticationService: ImplicitAutenticationService,) {
     this.translate = translate;
     this.translate.onLangChange.subscribe((event: LangChangeEvent) => { });
     this.total = true;
@@ -217,8 +219,32 @@ export class EvaluacionAspirantesComponent implements OnInit {
     if (this.selectednivel !== NaN) {
       this.projectService.get('proyecto_academico_institucion?limit=0').subscribe(
         (response: any) => {
-          this.proyectos = <any[]>response.filter(
-            proyecto => this.filtrarProyecto(proyecto),
+          this.autenticationService.getRole().then(
+            (rol: Array <String>) => {
+              let r = rol.find(role => (role == "ADMIN_SGA")); // rol admin, pendiente vice
+              if (r) {
+                this.proyectos = <any[]>response.filter(
+                  proyecto => this.filtrarProyecto(proyecto),
+                );
+              } else {
+                const id_tercero = this.userService.getPersonaId();
+                this.sgaMidService.get('admision/dependencia_vinculacion_tercero/'+id_tercero).subscribe(
+                  (respDependencia: any) => {
+                    const dependencias = <Number[]>respDependencia.Data.DependenciaId;
+                    this.proyectos = <any[]>response.filter(
+                      proyecto => dependencias.includes(proyecto.Id)
+                    );
+                    if (dependencias.length > 1) {
+                      this.popUpManager.showAlert(this.translate.instant('GLOBAL.info'),this.translate.instant('admision.multiple_vinculacion')+". "+this.translate.instant('GLOBAL.comunicar_OAS_error'));
+                      this.proyectos.forEach(p => { p.Id = undefined })
+                    }
+                  },
+                  (error: any) => {
+                    this.popUpManager.showErrorAlert(this.translate.instant('admision.no_vinculacion_no_rol')+". "+this.translate.instant('GLOBAL.comunicar_OAS_error'));
+                  }
+                );
+              }
+            }
           );
         },
         error => {

--- a/src/app/pages/admision/evaluacion-documentos-inscritos/evaluacion-documentos-inscritos.component.html
+++ b/src/app/pages/admision/evaluacion-documentos-inscritos/evaluacion-documentos-inscritos.component.html
@@ -32,7 +32,7 @@ nbSpinnerMessage="{{ 'GLOBAL.cargando' | translate }}">
                         [(ngModel)]="proyectos_selected"
                         (selectionChange)="loadInscritos()"
                         [disabled]='selectprograma'>
-              <mat-option *ngFor="let item of proyectos" [value]="item.Id">{{item.Nombre}}</mat-option>
+              <mat-option *ngFor="let item of proyectos" [value]="item.Id" [disabled]="!item.Id">{{item.Nombre}}</mat-option>
             </mat-select>
             <mat-error *ngIf="Campo1Control.hasError('required')">{{ 'admision.error_proyecto' | translate }}</mat-error>
           </mat-form-field>
@@ -44,6 +44,7 @@ nbSpinnerMessage="{{ 'GLOBAL.cargando' | translate }}">
             </nb-card-header>
             <nb-card-body class="d-flex justify-content-around align-items-center">
               <label>{{ 'admision.estado_inscrito' | translate }}: <b>{{cantidad_inscritos}}</b></label>
+              <label>{{ 'admision.estado_inscrito_observacion' | translate }}: <b>{{cantidad_inscritos_obs}}</b></label>
               <label>{{ 'admision.estado_admitido' | translate }}: <b>{{cantidad_admitidos}}</b></label>
               <label>{{ 'admision.total_aspirantes' | translate }}: <b>{{cantidad_aspirantes}}</b></label>
             </nb-card-body>

--- a/src/app/pages/admision/listado_aspirantes/listado_aspirante.component.html
+++ b/src/app/pages/admision/listado_aspirantes/listado_aspirante.component.html
@@ -72,7 +72,7 @@
                           [(ngModel)]="proyectos_selected"
                           (selectionChange)="activar_button()"
                           [disabled]='selectprograma'>
-                <mat-option *ngFor="let item of proyectos" [value]="item">
+                <mat-option *ngFor="let item of proyectos" [value]="item" [disabled]="!item.Id">
                   {{item.Nombre}}
                 </mat-option>
               </mat-select>
@@ -97,6 +97,7 @@
     <label>{{ 'admision.estado_opcionado' | translate }}: <b>{{cantidad_opcionados}}</b></label>
     <label>{{ 'admision.estado_no_admitido' | translate }}: <b>{{cantidad_no_admitidos}}</b></label>
     <label>{{ 'admision.estado_inscrito' | translate }}: <b>{{cantidad_inscritos}}</b></label>
+    <label>{{ 'admision.estado_inscrito_observacion' | translate }}: <b>{{cantidad_inscritos_obs}}</b></label>
     <label>{{ 'admision.total_aspirantes' | translate }}: <b>{{cantidad_aspirantes}}</b></label>
   </nb-card-body>
 </nb-card>

--- a/src/app/pages/admision/listado_aspirantes/listado_aspirante.component.ts
+++ b/src/app/pages/admision/listado_aspirantes/listado_aspirante.component.ts
@@ -22,6 +22,8 @@ import { IAppState } from '../../../@core/store/app.state';
 import { Store } from '@ngrx/store';
 import { ListService } from '../../../@core/store/services/list.service';
 import { SgaMidService } from '../../../@core/data/sga_mid.service';
+import { UserService } from '../../../@core/data/users.service';
+import { ImplicitAutenticationService } from '../../../@core/utils/implicit_autentication.service';
 
 @Component({
   // tslint:disable-next-line: component-selector
@@ -79,6 +81,7 @@ export class ListadoAspiranteComponent implements OnInit, OnChanges {
   cantidad_opcionados: number = 0;
   cantidad_no_admitidos: number = 0;
   cantidad_inscritos: number = 0;
+  cantidad_inscritos_obs: number = 0;
   mostrarConteos: boolean = false;
 
 
@@ -99,6 +102,8 @@ export class ListadoAspiranteComponent implements OnInit, OnChanges {
     private store: Store<IAppState>,
     private listService: ListService,
     private sgaMidService: SgaMidService,
+    private userService: UserService,
+    private autenticationService: ImplicitAutenticationService,
     ) {
 
     this.translate = translate;
@@ -376,8 +381,32 @@ export class ListadoAspiranteComponent implements OnInit, OnChanges {
     if (this.selectednivel !== NaN && this.selectednivel !== undefined) {
       this.projectService.get('proyecto_academico_institucion?limit=0').subscribe(
         (response: any) => {
-          this.proyectos = <any[]>response.filter(
-            proyecto => this.filtrarProyecto(proyecto),
+          this.autenticationService.getRole().then(
+            (rol: Array <String>) => {
+              let r = rol.find(role => (role == "ADMIN_SGA")); // rol admin, pendiente vice
+              if (r) {
+                this.proyectos = <any[]>response.filter(
+                  proyecto => this.filtrarProyecto(proyecto),
+                );
+              } else {
+                const id_tercero = this.userService.getPersonaId();
+                this.sgaMidService.get('admision/dependencia_vinculacion_tercero/'+id_tercero).subscribe(
+                  (respDependencia: any) => {
+                    const dependencias = <Number[]>respDependencia.Data.DependenciaId;
+                    this.proyectos = <any[]>response.filter(
+                      proyecto => dependencias.includes(proyecto.Id)
+                    );
+                    if (dependencias.length > 1) {
+                      this.popUpManager.showAlert(this.translate.instant('GLOBAL.info'),this.translate.instant('admision.multiple_vinculacion')+". "+this.translate.instant('GLOBAL.comunicar_OAS_error'));
+                      this.proyectos.forEach(p => { p.Id = undefined })
+                    }
+                  },
+                  (error: any) => {
+                    this.popUpManager.showErrorAlert(this.translate.instant('admision.no_vinculacion_no_rol')+". "+this.translate.instant('GLOBAL.comunicar_OAS_error'));
+                  }
+                );
+              }
+            }
           );
         },
         error => {
@@ -441,7 +470,8 @@ export class ListadoAspiranteComponent implements OnInit, OnChanges {
             this.cantidad_opcionados = this.Aspirantes.filter((inscripcion) => (inscripcion.EstadoInscripcionId.Nombre === 'OPCIONADO')).length;
             this.cantidad_no_admitidos = this.Aspirantes.filter((inscripcion) => (inscripcion.EstadoInscripcionId.Nombre === 'NO ADMITIDO')).length;
             this.cantidad_inscritos = this.inscritos.length;
-            this.cantidad_aspirantes = this.cantidad_inscrip_solicitada + this.cantidad_admitidos + this.cantidad_opcionados + this.cantidad_no_admitidos + this.cantidad_inscritos;
+            this.cantidad_inscritos_obs = this.Aspirantes.filter((inscripcion) => (inscripcion.EstadoInscripcionId.Nombre === 'INSCRITO con Observación')).length;
+            this.cantidad_aspirantes = this.cantidad_inscrip_solicitada + this.cantidad_admitidos + this.cantidad_opcionados + this.cantidad_no_admitidos + this.cantidad_inscritos + this.cantidad_inscritos_obs;
 
             this.source_emphasys.load(this.Aspirantes);
             this.loading = false;

--- a/src/app/pages/calendario-academico/administracion-calendario/administracion-calendario.component.ts
+++ b/src/app/pages/calendario-academico/administracion-calendario/administracion-calendario.component.ts
@@ -84,6 +84,12 @@ idCalendario: number = 0;
             this.getProgramaIdByUser().then((id: number) => {
               this.DependenciaID = id;
               this.getInfoPrograma(this.DependenciaID);
+            },(err: any) => {
+              if (err) {
+                this.popUpManager.showAlert(this.translate.instant('GLOBAL.info'),this.translate.instant('admision.multiple_vinculacion')+". "+this.translate.instant('GLOBAL.comunicar_OAS_error'));
+              } else {
+                this.popUpManager.showErrorAlert(this.translate.instant('admision.no_vinculacion_no_rol')+". "+this.translate.instant('GLOBAL.comunicar_OAS_error'));
+              }
             })
           }
       }
@@ -327,18 +333,18 @@ idCalendario: number = 0;
   getProgramaIdByUser() {
     return new Promise((resolve, reject) => {
       this.userId = this.userService.getPersonaId();
-      this.terceroService.get("vinculacion?query=Activo:true,tercero_principal_id:" + this.userId)
+      this.sgaMidService.get('admision/dependencia_vinculacion_tercero/'+this.userId)
         .subscribe(
-          (response: Vinculacion[]) => {
-            let dependenciaId = response[0].DependenciaId || 0;
-            if (dependenciaId > 0){
-              resolve(dependenciaId)
+          (respDependencia: any) => {
+            const dependencias = <Number[]>respDependencia.Data.DependenciaId;
+            if (dependencias.length == 1){
+              resolve(dependencias[0])
             } else {
-              reject("No valid Ids")
+              reject(dependencias)
             }
           },
           (error) => {
-            reject("Fail to connect")
+            reject(null)
           }
         );
     });  

--- a/src/app/pages/inscripcion/inscripcion_general/inscripcion_general.component.html
+++ b/src/app/pages/inscripcion/inscripcion_general/inscripcion_general.component.html
@@ -9,7 +9,7 @@
         nbSpinnerMessage="{{ 'GLOBAL.cargando' | translate }}">
         <nb-card-header>
             <div *ngIf="!hide_header_labels">
-                <div class="preinscription-alert">
+                <div class="preinscription-alert" *ngIf="!estaInscrito">
                     {{ 'inscripcion.alerta_preinscripcion' | translate }}
                 </div>
 
@@ -383,9 +383,9 @@
                 </div>
                 <div class="col-md-1" align="right">
                     <button class="btn btn-danger btn-icon input-group-text btn-tn" (click)="show_profile=false; show_info_pregrado=false;
-                                                                    show_acad=false; show_expe=false; show_proy=false;
+                                                                    show_acad=false; show_idiomas=false; show_expe=false; show_proy=false;
                                                                     show_prod=false; show_docu=false; show_info_externa=false;
-                                                                    show_desc=false; mostrarBarraExterna();">X
+                                                                    show_desc=false; mostrarBarraExterna(); redirectBecauseObservations();">X
                     </button>
                 </div>
             </div>
@@ -425,9 +425,9 @@
                 </div>
                 <div class="col-md-1" align="right">
                     <button class="btn btn-danger btn-icon input-group-text btn-tn" (click)="show_profile=false; show_info_pregrado=false;
-                            show_acad=false; show_expe=false; show_proy=false;
+                            show_acad=false; show_idiomas=false; show_expe=false; show_proy=false;
                             show_prod=false; show_docu=false; show_info_externa=false;
-                            show_desc=false; mostrarBarraExterna();">X
+                            show_desc=false; mostrarBarraExterna(); redirectBecauseObservations();">X
                     </button>
                 </div>
             </div>
@@ -466,8 +466,8 @@
                 </div>
                 <div class="col-md-1" align="right">
                     <button class="btn btn-danger btn-icon input-group-text btn-tn" (click)="show_profile=false; show_info=false; show_acad=false;
-                            show_expe=false; show_proy=false; show_prod=false; show_docu=false;
-                            show_desc=false; showRegreso=true; mostrarBarraExterna();">X
+                            show_idiomas=false; show_expe=false; show_proy=false; show_prod=false; show_docu=false;
+                            show_desc=false; showRegreso=true; mostrarBarraExterna(); redirectBecauseObservations();">X
                     </button>
                 </div>
             </div>
@@ -508,8 +508,8 @@
                 </div>
                 <div class="col-md-1" align="right">
                     <button class="btn btn-danger btn-icon input-group-text btn-tn" (click)="show_profile=false; show_info_pregrado=false; show_acad_pregrado=false;
-                            show_expe=false; show_proy=false; show_prod=false; show_docu=false;
-                            show_desc=false; showRegreso=true; mostrarBarraExterna();">X
+                            show_idiomas=false; show_expe=false; show_proy=false; show_prod=false; show_docu=false;
+                            show_desc=false; showRegreso=true; mostrarBarraExterna(); redirectBecauseObservations();">X
                     </button>
                 </div>
             </div>
@@ -538,8 +538,8 @@
                 </div>
                 <div class="col-md-1" align="right">
                     <button class="btn btn-danger btn-icon input-group-text btn-tn" (click)="show_profile=false; show_info=false; show_acad=false;
-                            show_expe=false; show_proy=false; show_prod=false; show_docu=false;
-                            show_desc=false; showRegreso=true; mostrarBarraExterna();">X
+                            show_idiomas=false; show_expe=false; show_proy=false; show_prod=false; show_docu=false;
+                            show_desc=false; showRegreso=true; mostrarBarraExterna(); redirectBecauseObservations();">X
                     </button>
                 </div>
             </div>
@@ -567,7 +567,7 @@
                 <div class="col-md-1" align="right">
                     <button class="btn btn-danger btn-icon input-group-text btn-tn" (click)="show_profile=false; show_info=false; show_acad=false;
                             show_idiomas=false; show_expe=false; show_proy=false; show_prod=false; show_docu=false;
-                            show_desc=false; showRegreso=true; mostrarBarraExterna();">X
+                            show_desc=false; showRegreso=true; mostrarBarraExterna(); redirectBecauseObservations();">X
                     </button>
                 </div>
             </div>
@@ -595,8 +595,8 @@
                 </div>
                 <div class="col-md-1" align="right">
                     <button class="btn btn-danger btn-icon input-group-text btn-tn" (click)="show_profile=false; show_info=false; show_acad=false;
-                            show_expe=false; show_proy=false; show_prod=false; show_docu=false;
-                            show_desc=false; showRegreso=true; mostrarBarraExterna();">X
+                            show_idiomas=false; show_expe=false; show_proy=false; show_prod=false; show_docu=false;
+                            show_desc=false; showRegreso=true; mostrarBarraExterna(); redirectBecauseObservations();">X
                     </button>
                 </div>
             </div>
@@ -621,8 +621,8 @@
                 </div>
                 <div class="col-md-1" align="right">
                     <button class="btn btn-danger btn-icon input-group-text btn-tn" (click)="show_profile=false; show_info=false; show_acad=false;
-                            show_expe=false; show_proy=false; show_prod=false; show_docu=false;
-                            show_desc=false; showRegreso=true; mostrarBarraExterna();">X
+                            show_idiomas=false; show_expe=false; show_proy=false; show_prod=false; show_docu=false;
+                            show_desc=false; showRegreso=true; mostrarBarraExterna(); redirectBecauseObservations();">X
                     </button>
                 </div>
             </div>
@@ -646,8 +646,8 @@
                 </div>
                 <div class="col-md-1" align="right">
                     <button class="btn btn-danger btn-icon input-group-text btn-tn" (click)="show_profile=false; show_info=false; show_acad=false;
-                            show_expe=false; show_proy=false; show_prod=false; show_docu=false;
-                            show_desc=false; showRegreso=true; mostrarBarraExterna();">X
+                            show_idiomas=false; show_expe=false; show_proy=false; show_prod=false; show_docu=false;
+                            show_desc=false; showRegreso=true; mostrarBarraExterna(); redirectBecauseObservations();">X
                     </button>
                 </div>
             </div>
@@ -672,8 +672,8 @@
                 </div>
                 <div class="col-md-1" align="right">
                     <button class="btn btn-danger btn-icon input-group-text btn-tn" (click)="show_profile=false; show_info=false; show_acad=false;
-                            show_expe=false; show_proy=false; show_prod=false; show_docu=false;
-                            show_desc=false; showRegreso=true; mostrarBarraExterna();">X
+                            show_idiomas=false; show_expe=false; show_proy=false; show_prod=false; show_docu=false;
+                            show_desc=false; showRegreso=true; mostrarBarraExterna(); redirectBecauseObservations();">X
                     </button>
                 </div>
             </div>
@@ -698,8 +698,8 @@
                 </div>
                 <div class="col-md-1" align="right">
                     <button class="btn btn-danger btn-icon input-group-text btn-tn" (click)="show_profile=false; show_info=false; show_acad=false;
-                            show_expe=false; show_proy=false; show_prod=false; show_docu=false;
-                            show_desc=false; showRegreso=true; mostrarBarraExterna();">X
+                            show_idiomas=false; show_expe=false; show_proy=false; show_prod=false; show_docu=false;
+                            show_desc=false; showRegreso=true; mostrarBarraExterna(); redirectBecauseObservations();">X
                     </button>
                 </div>
             </div>

--- a/src/app/pages/inscripcion/inscripcion_general/inscripcion_general.component.ts
+++ b/src/app/pages/inscripcion/inscripcion_general/inscripcion_general.component.ts
@@ -197,6 +197,7 @@ export class InscripcionGeneralComponent implements OnInit, OnChanges {
   }
 
   async loadData() {
+    this.estado_inscripcion_nombre = <string>sessionStorage.getItem('IdEstadoInscripcion').toUpperCase();
     this.inscripcion = new Inscripcion();
     this.inscripcion.Id = parseInt(sessionStorage.getItem('IdInscripcion'), 10);
     this.inscripcion.ProgramaAcademicoId = sessionStorage.getItem('ProgramaAcademico');
@@ -487,6 +488,8 @@ export class InscripcionGeneralComponent implements OnInit, OnChanges {
         if (!enAlgunaVista && this.estado_inscripcion_nombre == "INSCRIPCIÓN SOLICITADA"){
           this.popUpManager.showPopUpGeneric(this.translate.instant('inscripcion.inscripcion'), this.translate.instant('inscripcion.mensaje_100_inscripcion'), "info", false)
         }
+      } else {
+        this.total = true;
       }
     }
     // if (this.info_inscripcion !== undefined) {
@@ -700,36 +703,13 @@ export class InscripcionGeneralComponent implements OnInit, OnChanges {
       this.inscripcionService.get('soporte_documento_programa?query=InscripcionId.Id:' +
         this.inscripcion.Id + ',DocumentoProgramaId.ProgramaId:' + parseInt(sessionStorage.ProgramaAcademicoId, 10) + ',DocumentoProgramaId.TipoInscripcionId:' + parseInt(sessionStorage.getItem('IdTipoInscripcion'), 10) + ',DocumentoProgramaId.PeriodoId:' + parseInt(sessionStorage.getItem('IdPeriodo'), 10) + ',DocumentoProgramaId.Activo:true,DocumentoProgramaId.Obligatorio:true&limit=0').subscribe(
           (res: any[]) => {
-            if (res !== null && JSON.stringify(res[0]) !== '{}') {
-              let percentage_docu = 0;
-              for (let i = 0; i < res.length; i++) {
-                this.documentoService.get('documento/' + res[i].DocumentoId).subscribe(
-                  response => {
-
-                    if (response.Metadatos === '') {
-                      percentage_docu += 1;
-                    } else {
-                      if (response.Metadatos !== '') {
-                        let metadata = JSON.parse(response.Metadatos);
-                        if (JSON.hasOwnProperty('aprobado')){
-                          if (JSON.parse(response.Metadatos).aprobado) {
-                            percentage_docu += 1;
-                          }
-                        } else {
-                          percentage_docu += 1;
-                        }
-                      }
-                    }
-
-                    this.percentage_docu = Math.round((percentage_docu/this.tipo_documentos.length * 100));
-                    if(this.percentage_docu >= 100){
-                      this.percentage_docu = 100;
-                    }
-
-                    this.percentage_tab_docu[0] = Math.round(this.percentage_docu);
-                    this.loading = false;
-                  })
-              };
+            if (Object.keys(res[0]).length > 0) {
+              this.percentage_docu = Math.round((res.length / this.tipo_documentos.length) * 100);
+              if(this.percentage_docu >= 100){
+                this.percentage_docu = 100;
+              }
+              this.percentage_tab_docu[0] = Math.round(this.percentage_docu);
+              this.loading = false;
               resolve(this.percentage_docu);
             } else {
               this.percentage_docu = 0;
@@ -796,32 +776,26 @@ export class InscripcionGeneralComponent implements OnInit, OnChanges {
     });
   }
 
-  public loadLists() {
+  loadLists() {  
+    return new Promise((resolve, reject) => {
     this.inscripcionService.get('documento_programa?query=Activo:true,ProgramaId:' + parseInt(sessionStorage.ProgramaAcademicoId, 10) + ',TipoInscripcionId:' + parseInt(sessionStorage.getItem('IdTipoInscripcion'), 10) + ',PeriodoId:'+sessionStorage.getItem('IdPeriodo') + ',Obligatorio:true&limit=0').subscribe(
       response => {
-        this.tipo_documentos = <any[]>response;
+        if (Object.keys(response[0]).length > 0) {
+          this.tipo_documentos = <any[]>response;
+        } else {
+          this.tipo_documentos = [];
+        }
+        resolve(this.tipo_documentos)
       },
       error => {
         this.popUpManager.showErrorToast(this.translate.instant('ERROR.general'));
+        reject(error)
       },
     );
+    });
   }
 
   ngOnInit() {
-    this.estado_inscripcion_nombre = <string>sessionStorage.getItem('IdEstadoInscripcion').toUpperCase();
-    
-    if (this.estado_inscripcion_nombre !== "INSCRIPCIÓN SOLICITADA") {
-      this.Campo1Control.disable();
-      this.enfasisControl.disable();
-      this.estaInscrito = true;
-      const IdPeriodo = parseInt(sessionStorage.getItem('IdPeriodo'), 10);
-      const IdTipo = parseInt(sessionStorage.getItem('IdTipoInscripcion'), 10)
-      const IdPrograma = parseInt(sessionStorage.getItem('ProgramaAcademicoId'), 10)
-      this.loadSuitePrograma(IdPeriodo, IdPrograma, IdTipo);
-      this.soloPuedeVer = true;
-      this.puedeInscribirse = false;
-      localStorage.setItem("goToEdit", String(this.puedeInscribirse));
-    }
   }
 
   async getPorcentajes() {
@@ -878,11 +852,11 @@ export class InscripcionGeneralComponent implements OnInit, OnChanges {
     if (this.percentage_prod === 0 && this.tagsObject.produccion_academica.selected) {
       await this.loadPercentageProduccionAcademica();
     }
-
     // Consulta si hay información en documentos solicitados
     if (this.percentage_docu === 0 && this.tagsObject.documento_programa.selected) {
-      await this.loadLists();
-      await this.loadPercentageDocumentos();
+      await this.loadLists().then(async () => {
+        await this.loadPercentageDocumentos();
+      })
     }
 
     // Consulta si hay información en descuento
@@ -894,8 +868,27 @@ export class InscripcionGeneralComponent implements OnInit, OnChanges {
     if (this.percentage_proy === 0 && this.tagsObject.propuesta_grado.selected) {
       await this.loadPercentageTrabajoDeGrado();
     }
-
     this.setPercentage_total();
+  }
+
+  resetPercentages() {
+    this.percentage_total = 0;
+    this.percentage_info = 0;
+    this.percentage_acad = 0;
+    this.percentage_idio = 0;
+    this.percentage_expe = 0;
+    this.percentage_prod = 0;
+    this.percentage_docu = 0;
+    this.percentage_desc = 0;
+    this.percentage_proy = 0;
+    this.percentage_tab_info = [];
+    this.percentage_tab_acad = [];
+    this.percentage_tab_idio = [];
+    this.percentage_tab_expe = [];
+    this.percentage_tab_prod = [];
+    this.percentage_tab_docu = [];
+    this.percentage_tab_desc = [];
+    this.percentage_tab_proy = [];
   }
 
   realizarInscripcion() {
@@ -1295,7 +1288,7 @@ export class InscripcionGeneralComponent implements OnInit, OnChanges {
   ngOnChanges() {
   }
 
-  tipo_inscripcion(select) {
+  async tipo_inscripcion(select) {
     if (select == 'programa') {
       this.enfasisSelected = undefined;
       this.tagsObject = {...TAGS_INSCRIPCION_PROGRAMA};
@@ -1357,37 +1350,63 @@ export class InscripcionGeneralComponent implements OnInit, OnChanges {
 
     if (select == 'enfasis') {
       if (this.enfasisSelected) {
-        if (this.checkEventoInscripcion()) {
-          const IdPeriodo = parseInt(sessionStorage.getItem('IdPeriodo'), 10);
-          const IdTipo = parseInt(sessionStorage.getItem('IdTipoInscripcion'), 10)
-          this.loadSuitePrograma(IdPeriodo, this.selectedValue, IdTipo);
+        this.resetPercentages();
+        const IdPeriodo = parseInt(sessionStorage.getItem('IdPeriodo'), 10);
+        const IdTipo = parseInt(sessionStorage.getItem('IdTipoInscripcion'), 10)
+        if(await this.loadSuitePrograma(IdPeriodo, this.selectedValue, IdTipo)) {
+          if (this.estado_inscripcion_nombre !== "INSCRIPCIÓN SOLICITADA") {
+            this.Campo1Control.disable();
+            this.enfasisControl.disable();
+            this.estaInscrito = true;
+            this.soloPuedeVer = true;
+            this.puedeInscribirse = false;
+            localStorage.setItem("goToEdit", String(this.puedeInscribirse));
+            if (this.estado_inscripcion_nombre == "INSCRITO CON OBSERVACIÓN"){
+              this.popUpManager.showPopUpGeneric(this.translate.instant('inscripcion.inscripcion'), 
+                    this.translate.instant('inscripcion.informar_estado_inscrito_obs'), "info", false);
+            }
+          } else if (await this.checkEventoInscripcion()) {
+            this.percentage_total = 0;
+            await this.getPorcentajes();
+          }
         }
       }
     }
   }
 
+  redirectBecauseObservations() {
+    if (this.estado_inscripcion_nombre == "INSCRITO CON OBSERVACIÓN"){
+      this.popUpManager.showPopUpGeneric(this.translate.instant('inscripcion.inscripcion'), 
+            this.translate.instant('inscripcion.info_boton_cambio_inscrito'), "info", false);
+      this.perfil_editar('perfil');
+    }
+  }
+
   loadSuitePrograma(periodo, proyecto, tipoInscrip) {
+    return new Promise((resolve) => {
     this.loading = true;
     this.evaluacionInscripcionService.get('tags_por_dependencia?query=Activo:true,PeriodoId:'+periodo+',DependenciaId:'+proyecto+',TipoInscripcionId:'+tipoInscrip)
         .subscribe((response: any) => {
           if (response != null && response.Status == '200') {
             if (Object.keys(response.Data[0]).length > 0) {
               this.tagsObject = JSON.parse(response.Data[0].ListaTags);
-              this.getPorcentajes();
               this.loading = false;
+              resolve(this.tagsObject)
             } else {
               this.loading = false;
               this.tagsObject = {...TAGS_INSCRIPCION_PROGRAMA};
               this.puedeInscribirse = false;
               this.soloPuedeVer = false;
               this.popUpManager.showAlert(this.translate.instant('inscripcion.preinscripcion'), this.translate.instant('admision.no_tiene_suite'));
+              resolve(false);
             }
           } else {
             this.loading = false;
             this.tagsObject = {...TAGS_INSCRIPCION_PROGRAMA};
             this.puedeInscribirse = false;
             this.soloPuedeVer = false;
-              this.popUpManager.showAlert(this.translate.instant('inscripcion.preinscripcion'), this.translate.instant('admision.no_tiene_suite'));
+            this.popUpManager.showAlert(this.translate.instant('inscripcion.preinscripcion'), this.translate.instant('admision.no_tiene_suite'));
+            resolve(false);
           }
         },
         (error: HttpErrorResponse) => {
@@ -1396,7 +1415,9 @@ export class InscripcionGeneralComponent implements OnInit, OnChanges {
           this.puedeInscribirse = false;
           this.soloPuedeVer = false;
           this.popUpManager.showErrorToast(this.translate.instant('ERROR.general'));
+          resolve(false);
         });
+  });
   }
 
   mostrarBarraExterna() {

--- a/src/app/pages/inscripcion/perfil/perfil.component.html
+++ b/src/app/pages/inscripcion/perfil/perfil.component.html
@@ -217,9 +217,8 @@
       <ngb-progressbar id="progressbar" type="success" [value]="progressDownloadDocs" [striped]="loading" [animated]="true">
       </ngb-progressbar>
       <br>
-      <div class="preinscription-alert" *ngIf="(contTag < maxTags)">
-        <div class="col-md-12"> {{ 'inscripcion.info_completar_carga' | translate }} </div>
-        <div class="col-md-12" *ngIf="imprimir" > {{ 'inscripcion.info_impresion_auto' | translate }} </div>
+      <div class="preinscription-alert" *ngIf="imprimir">
+        <div class="col-md-12"> {{ 'inscripcion.info_impresion_auto' | translate }} </div>
       </div>
       <div class="info-comprobante" *ngIf="imprimir">
         {{ 'inscripcion.info_comprobante' | translate }}

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -647,7 +647,8 @@
         "opcional": "Optional",
         "tooltip_previsualizar_archivo": "Preview selected file",
         "tooltip_descargar_arhivo": "Download online file",
-        "seleccionar_archivo": "Select file"
+        "seleccionar_archivo": "Select file",
+        "comunicar_OAS_error": "Please contact the Systems Advisory Office (Oficina Asesora de Sistemas) to attend to the problem"
     },
     "ERROR": {
         "general": "The request could not be satisfied",
@@ -1357,7 +1358,6 @@
         "correo_anterior": "Previous email",
         "correo_actual": "Current email",
         "generar_comprobante": "If you have not saved or the receipt has not been generated, click here",
-        "info_completar_carga": "Review the information sections one by one to complete the process. To advance press next, it will be finished when the loading bar is complete.",
         "info_impresion_auto": "NOTE: A proof of enrollment document is generated upon completion of the loading bar.",
         "fallo_carga_mensaje": "Something failed to load information, please come back and try again",
         "sin_documento": "The file you are trying to view cannot be found",
@@ -1365,7 +1365,9 @@
         "cambio_estado_ok": "Confirmation of successful edition",
         "nota_confirmar_ajuste": "Currently your enrollment presents observations in some related documents, please update the unapproved documents to enable the button that confirms the edition. Don't forget to press this button or your registration status will not be updated.",
         "no_edit_doc_aprobado": "You cannot edit approved document",
-        "ya_existe_registro" : "You already have information loaded for this field"
+        "ya_existe_registro" : "You already have information loaded for this field",
+        "informar_estado_inscrito_obs": "Applicant, your enrollment is conditioned by observations in the attached documentation, please go to Registration Details to review and correct the information not approved. If you do not, you cannot continue with the process.",
+        "info_boton_cambio_inscrito": "Do not forget to press the button \"Confirm edition of documents with observations\" to return to the ENROLLED status, this is enabled when you have edited all the not approved documents."
     },
     "reingreso": {
         "reingreso_no_registrado": "Re-entry request not created",
@@ -1630,9 +1632,11 @@
         "estado_opcionado": "Optioned",
         "estado_no_admitido": "Unadmitted",
         "estado_inscrito": "Enrolled",
+        "estado_inscrito_observacion": "Enrolled with observation",
         "resumen_estados_inscripcion": "Summary status of applicants",
-        "descargar_zip": "Download the applicant's documentary compilation"
-
+        "descargar_zip": "Download the applicant's documentary compilation",
+        "no_vinculacion_no_rol": "Your user is not linked to any academic project and does not have the appropriate role",
+        "multiple_vinculacion": "Your user appears linked to more than one academic project"
     },
     "cupos": {
         "aviso_periodo": "Period in which the admission quotas are defined",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -682,7 +682,8 @@
         "opcional": "Opcional",
         "tooltip_previsualizar_archivo": "Previsualizar archivo seleccionado",
         "tooltip_descargar_arhivo": "Descargar archivo en línea",
-        "seleccionar_archivo": "Seleccionar archivo"
+        "seleccionar_archivo": "Seleccionar archivo",
+        "comunicar_OAS_error": "Por favor comuníquese con Oficina Asesora de Sistemas (OAS) para atender el problema"
     },
     "ERROR": {
         "general": "La solicitud no pudo ser cumplida",
@@ -1393,15 +1394,16 @@
         "correo_anterior": "Correo anterior",
         "correo_actual": "Correo actual",
         "generar_comprobante": "Si no ha guardado o no se ha generado el comprobante, presione aquí",
-        "info_completar_carga": "Revise uno a uno los apartados de información para completar el proceso. Para avanzar presione siguiente, habrá finalizado cuando la barra de carga se complete.",
         "info_impresion_auto": "NOTA: Se genera un documento comprobante de inscripción al completar la barra de carga.",
         "fallo_carga_mensaje": "Algó falló en la carga de información, por favor regrese e intente de nuevo",
         "sin_documento": "El archivo que intenta visualizar no se encuentra",
         "confirmar_ajuste_documentos_observacion": "Confirmar edición de documentos con observaciones",
         "cambio_estado_ok": "Confirmación de edición exitosa",
-        "nota_confirmar_ajuste": "Actualmente su inscripción presenta observaciones en algunos documentos relacionados, por favor actualice los documentos no aprobados para habilitar el botón que comfirma la edición. No olvide presionar este botón o su estado de inscripción no será actualizado.",
+        "nota_confirmar_ajuste": "Actualmente su inscripción presenta observaciones en algunos documentos relacionados, por favor actualice los documentos no aprobados para habilitar el botón que confirma la edición. No olvide presionar este botón o su estado de inscripción no será actualizado.",
         "no_edit_doc_aprobado": "No puedes editar documento aprobado",
-        "ya_existe_registro" : "Ya cuenta con información cargada para este campo"
+        "ya_existe_registro" : "Ya cuenta con información cargada para este campo",
+        "informar_estado_inscrito_obs": "Aspirante, su inscripción se encuentra condicionada por observaciones en documentación adjunta, por favor diríjase a Detalle de inscripción para revisar y corregir la información no aprobada. Si no lo hace no puede continuar con el proceso.",
+        "info_boton_cambio_inscrito": "No olvide presionar el botón \"Confirmar edición de documentos con observaciones\" para volver al estado INSCRITO, este se habilita cuando haya editado todos los documentos no aprobados."
     },
     "reingreso": {
         "reingreso_no_registrado": "Solicitud de reingreso no registrada",
@@ -1662,8 +1664,11 @@
         "estado_opcionado": "Opcionado",
         "estado_no_admitido": "No Admitido",
         "estado_inscrito": "Inscrito",
+        "estado_inscrito_observacion": "Inscrito con observación",
         "resumen_estados_inscripcion": "Resumen estados de inscripción aspirantes",
-        "descargar_zip": "Descargar compilado documental del aspirante"
+        "descargar_zip": "Descargar compilado documental del aspirante",
+        "no_vinculacion_no_rol": "Su usuario no se encuentra vinculado a ningun proyecto curricular ni cuenta con el rol adecuado",
+        "multiple_vinculacion": "Su usuario aparece vinculado a más de un proyecto curricular"
     },
     "cupos": {
         "aviso_periodo": "Período en el cual se define los cupos de admisión",


### PR DESCRIPTION
- https://github.com/udistrital/sga_cliente/issues/1237
- Se ajusta funcionalidad en varios selects _(proyecto académico)_ del módulo de admisiones, para que solo cargue el proyecto académico dependiendo de la vinculación del tercero, o cargarlos todos si es ADMIN o VICE (está pendiente rol VICE)
- También se aprovecha para incluir ese ajuste en Administración de Calendario, ahí también se basa en la vinculación del tercero.

Adicional:
 - Se Ajusta contadores de estados de inscripción en listados de aspirantes, esto para incluir: INSCRITO con Observación.
 - Se añaden modales para indicar al aspirante en estado de Inscrito con Observación que revise documentación y que confirme los ajustes.
 - Ya estando en esas, se ajusta flujo en rol aspirante en vistas de inscripción cuando está con observaciones; también se aprovecha para corregir y simplificar flujos en la carga de la suite y la verificación de porcentajes, particularmente documentos_solicitados tenía bugs que solo eran visibles en ciertas situaciones.