### PR TITLE
hotfix: numeracion lista de aspirantes

### DIFF
--- a/src/app/pages/admision/listado_aspirantes/listado_aspirante.component.ts
+++ b/src/app/pages/admision/listado_aspirantes/listado_aspirante.component.ts
@@ -159,9 +159,11 @@ export class ListadoAspiranteComponent implements OnInit, OnChanges {
         index:{
           title: '#',
           filter: false,
-          valuePrepareFunction: (value,row,cell) => {
-            return cell.row.index+1;
-           },
+          type: 'html',
+          valuePrepareFunction: (value, row, cell) => {
+            const absoluteIndex = (cell.row.index + 1) + (this.source_emphasys.getPaging().page - 1) * this.source_emphasys.getPaging().perPage;
+            return `<div>${absoluteIndex}</div>`;
+          },
           width: '2%',
         },
         NumeroDocumento: {


### PR DESCRIPTION
#1586 Se modifica la numeracion en la primera columna de la tabla de registros que se muestra en el listado de aspirantes con el fin de que la paginación continúe con la numeración  
![image](https://github.com/user-attachments/assets/6f85b32e-b1b1-4ed9-83b6-ae3a1b662302)
 