### PR TITLE
hotfix: numeracion evaluacion documentos de inscritos

### DIFF
--- a/src/app/pages/admision/evaluacion-documentos-inscritos/evaluacion-documentos-inscritos.component.ts
+++ b/src/app/pages/admision/evaluacion-documentos-inscritos/evaluacion-documentos-inscritos.component.ts
@@ -358,6 +358,16 @@ export class EvaluacionDocumentosInscritosComponent implements OnInit {
   createTable() {
     this.settings = {
       columns: {
+        index:{
+          title: '#',
+          filter: false,
+          type: 'html',
+          valuePrepareFunction: (value, row, cell) => {
+            const absoluteIndex = (cell.row.index + 1) + (this.dataSource.getPaging().page - 1) * this.dataSource.getPaging().perPage;
+            return `<div>${absoluteIndex}</div>`;
+          },
+          width: '2%',
+        },
         Credencial: {
           title: this.translate.instant('admision.credencial'),
           width: '20%',


### PR DESCRIPTION
#1586 Se agrega la numeración de los registros en el módulo de evaluación de documentos de inscritos para que los asistentes de los proyectos curriculares puedan conocer la cantidad de registros que se muestran en dicho módulo

![image](https://github.com/user-attachments/assets/bd41bf3f-d30e-4596-8f18-6abb956d46a5)

