### PR TITLE
Hotfix: se corrige validación de acceso en definir conceptos 

### DIFF
--- a/src/app/pages/derechos-pecuniarios/derechos-pecuniarios-routing.module.ts
+++ b/src/app/pages/derechos-pecuniarios/derechos-pecuniarios-routing.module.ts
@@ -28,12 +28,12 @@ const routes: Routes = [{
         {
             path: 'copiar-conceptos',
             component: CopiarConceptosComponent,
-            canActivate: [AuthGuard],
+            //canActivate: [AuthGuard],
         },
         {
             path: 'definir-conceptos',
             component: DefinirConceptosComponent,
-            canActivate: [AuthGuard],
+            //canActivate: [AuthGuard],
         },
         {
             path: 'consultar-conceptos',


### PR DESCRIPTION
Se desactiva el AuthGuard de los componentes copiar-conceptos y definir-conceptos que ya tienen validación de acceso en el componente crud-derechos-pecuniarios para solucionar el error de permisos de usuario
![image](https://github.com/user-attachments/assets/d03e1fc1-aefd-44eb-8def-201edf98b27c)
