### PR TITLE
feat: inhabilitar recibos inscripción vencidos

### DIFF
--- a/src/app/pages/inscripcion/crud-inscripcion_multiple/crud-inscripcion_multiple.component.ts
+++ b/src/app/pages/inscripcion/crud-inscripcion_multiple/crud-inscripcion_multiple.component.ts
@@ -346,6 +346,16 @@ export class CrudInscripcionMultipleComponent implements OnInit {
                   dataInfo.push(element);
                   this.dataSource.load(dataInfo);
                   this.dataSource.setSort([{ field: 'Id', direction: 'desc' }]);
+                  if (element.Estado == "Vencido"){
+                    this.inscripcionService.get('inscripcion/' + element.Id)
+                    .subscribe(res =>{
+                      res.Activo = false;
+                      res.PeriodoId = 0;
+                      this.inscripcionService.put('inscripcion/', res).subscribe( ()=>{
+                        window.location.reload();
+                      });
+                    });
+                  }
                 },
                 error => {
                   this.loading = false;


### PR DESCRIPTION
[#636](https://github.com/udistrital/sga_documentacion/issues/636)
- Se agrega validación sobre recibos vencidos
- Los vencidos se actualizan vía API *inscripciones_crud* con el campo *Activo* en false y se desvinculan del periodo académico
- Permite al aspirante generar un nuevo recibo sin necesidad de solicitar la inactivación del vencido
